### PR TITLE
[STEP-7] Redis 기반 랭킹/대기열 시스템 구현

### DIFF
--- a/docs/Redis_랭킹_대기열_회고.md
+++ b/docs/Redis_랭킹_대기열_회고.md
@@ -1,0 +1,765 @@
+# 콘서트 예약 시스템 - Redis 기반 랭킹/대기열 구현 회고
+
+> 항해 플러스 LITE 7주차 과제  
+> 2025.11.03
+
+---
+
+## 1. Ranking Design - 빠른 매진 랭킹 시스템
+
+### 1.1 핵심 구현
+
+#### 판매 속도 기반 랭킹
+
+```java
+// ConcertRankingService.java
+private void updateVelocityRanking(Long scheduleId, long soldCount) {
+    Map<String, String> stats = rankingPort.getStats(String.valueOf(scheduleId));
+    String startTimeStr = stats.get("startTime");
+
+    if (startTimeStr == null) {
+        log.warn("startTime이 없음 - scheduleId: {}", scheduleId);
+        return;
+    }
+
+    try {
+        long startTime = Long.parseLong(startTimeStr);
+        long elapsedMinutes = (System.currentTimeMillis() - startTime) / 60000;
+        if (elapsedMinutes < 1) elapsedMinutes = 1;
+
+        // 분당 판매량 = 판매 속도
+        double velocity = soldCount / (double) elapsedMinutes;
+
+        // Port를 통해 랭킹 업데이트
+        rankingPort.updateVelocityRanking(String.valueOf(scheduleId), velocity);
+
+        log.debug("판매 속도 업데이트 - scheduleId: {}, velocity: {:.2f} tickets/min",
+                scheduleId, velocity);
+    } catch (NumberFormatException e) {
+        log.error("startTime 파싱 실패 - scheduleId: {}, startTime: {}",
+                scheduleId, startTimeStr);
+    }
+}
+```
+
+**설계 의도**
+- 단순 판매 수량만으로는 오래된 공연이 유리함
+- 시간을 고려한 "속도" 개념으로 "빠르게 팔리는" 공연 파악
+- 실시간성 있는 랭킹 제공
+
+#### Redis 자료구조 활용
+
+```java
+// RedisRankingAdapter.java
+@Override
+public long incrementSoldCount(String scheduleId, int increment) {
+    String key = SCHEDULE_STATS + scheduleId;
+
+    // Redis HINCRBY는 atomic 연산
+    Long newCount = redisTemplate.opsForHash().increment(key, "soldCount", increment);
+
+    // lastSaleTime도 함께 업데이트
+    redisTemplate.opsForHash().put(key, "lastSaleTime",
+            String.valueOf(System.currentTimeMillis()));
+
+    return newCount != null ? newCount : increment;
+}
+
+@Override
+public void updateVelocityRanking(String scheduleId, double score) {
+    redisTemplate.opsForZSet().add(VELOCITY_RANKING, "schedule:" + scheduleId, score);
+}
+```
+
+**선택한 자료구조**
+- **Hash**: 스케줄별 통계 정보 저장 (soldCount, startTime, totalSeats)
+- **Sorted Set**: velocity를 score로 사용하여 자동 정렬
+- `reverseRange(0, limit-1)`로 상위 랭킹 조회
+
+#### 캐싱 전략
+
+```java
+// ConcertRankingService.java
+@Cacheable(value = "concertRankings", key = "#limit")
+public List<ConcertRankingDto> getFastSellingRanking(int limit) {
+    log.debug("랭킹 조회 - Port를 통한 데이터 조회 (캐시 미스)");
+
+    // Port를 통해 상위 랭킹 조회
+    Set<String> topSchedules = rankingPort.getTopByVelocity(limit);
+
+    if (topSchedules.isEmpty()) {
+        return List.of();
+    }
+
+    // 1. scheduleId 목록 추출
+    List<Long> scheduleIds = topSchedules.stream()
+            .map(this::extractScheduleId)
+            .filter(Objects::nonNull)
+            .toList();
+
+    // 2. 배치로 한 번에 조회
+    Map<Long, ConcertSchedule> scheduleMap = schedulePort.findAllByIds(scheduleIds);
+
+    // 3. 랭킹 데이터 조합
+    List<ConcertRankingDto> result = new ArrayList<>();
+    int rank = 1;
+
+    for (String scheduleKey : topSchedules) {
+        try {
+            Long scheduleId = extractScheduleId(scheduleKey);
+            if (scheduleId == null) continue;
+
+            Map<String, String> stats = rankingPort.getStats(String.valueOf(scheduleId));
+            if (stats.isEmpty()) continue;
+
+            // 통계 정보 추출
+            int soldCount = getIntValue(stats.get("soldCount"));
+            double velocity = calculateVelocity(stats);
+            boolean isSoldOut = stats.containsKey("soldOutTime");
+            Integer soldOutSeconds = isSoldOut ?
+                    getIntValue(stats.get("soldOutSeconds")) : null;
+
+            // Map에서 조회
+            String concertName = Optional.ofNullable(scheduleMap.get(scheduleId))
+                    .map(schedule -> "Concert #" + scheduleId)
+                    .orElse("Unknown Concert #" + scheduleId);
+
+            result.add(new ConcertRankingDto(
+                    rank++,
+                    scheduleId,
+                    concertName,
+                    soldCount,
+                    velocity,
+                    isSoldOut,
+                    soldOutSeconds
+            ));
+
+        } catch (NumberFormatException e) {
+            log.warn("숫자 형식 오류 - scheduleKey: {}", scheduleKey);
+        } catch (Exception e) {
+            log.error("랭킹 항목 처리 실패 - scheduleKey: {}", scheduleKey, e);
+        }
+    }
+
+    return result;
+}
+
+@CacheEvict(value = "concertRankings", allEntries = true)
+public void trackReservation(Long scheduleId, int seatCount) {
+    String scheduleIdStr = String.valueOf(scheduleId);
+
+    // 매진 체크
+    Map<String, String> stats = rankingPort.getStats(scheduleIdStr);
+    if (stats.containsKey("soldOutTime")) {
+        log.debug("이미 매진된 공연 - scheduleId: {}", scheduleId);
+        return;
+    }
+
+    // 실제 총 좌석 수 조회
+    int totalSeats = getTotalSeats(scheduleId, stats);
+
+    // 첫 판매 시간 기록
+    rankingPort.setStartTimeIfAbsent(scheduleIdStr, System.currentTimeMillis());
+
+    // 판매 수량 증가
+    long newSoldCount = rankingPort.incrementSoldCount(scheduleIdStr, seatCount);
+
+    log.debug("예약 추적 - scheduleId: {}, 추가: {}석, 누적: {}석 / 총: {}석",
+            scheduleId, seatCount, newSoldCount, totalSeats);
+
+    // 판매 속도 랭킹 업데이트
+    updateVelocityRanking(scheduleId, newSoldCount);
+
+    // 실제 좌석 수 기준 매진 체크
+    if (newSoldCount >= totalSeats) {
+        recordSoldOut(scheduleId, totalSeats);
+    }
+}
+```
+
+### 1.2 겪었던 문제들
+
+#### 문제 1. Record 타입 직렬화 실패
+
+**상황**
+```
+ClassCastException: LinkedHashMap cannot be cast to ConcertRankingDto
+```
+
+처음 `GenericJackson2JsonRedisSerializer`를 사용했는데, Record 타입을 제대로 역직렬화하지 못했다. Redis에서 가져온 데이터가 LinkedHashMap으로 변환되어 타입 정보가 유실되었다.
+
+**해결**
+```java
+// RedisConfig.java
+@Bean
+public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    JdkSerializationRedisSerializer serializer = new JdkSerializationRedisSerializer();
+
+    // 기본 캐시 설정
+    RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues()
+            .serializeKeysWith(
+                    RedisSerializationContext.SerializationPair.fromSerializer(
+                            new StringRedisSerializer()
+                    )
+            )
+            .serializeValuesWith(
+                    RedisSerializationContext.SerializationPair.fromSerializer(serializer)
+            );
+
+    RedisCacheConfiguration concertsConfig = defaultConfig.entryTtl(Duration.ofDays(1));
+    RedisCacheConfiguration concertDetailConfig = defaultConfig.entryTtl(Duration.ofDays(1));
+    RedisCacheConfiguration scheduleConfig = defaultConfig.entryTtl(Duration.ofMinutes(1));
+    RedisCacheConfiguration rankingConfig = defaultConfig.entryTtl(Duration.ofSeconds(10));
+
+    return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig.entryTtl(Duration.ofMinutes(10)))
+            .withCacheConfiguration("concerts", concertsConfig)
+            .withCacheConfiguration("concertDetail", concertDetailConfig)
+            .withCacheConfiguration("schedule", scheduleConfig)
+            .withCacheConfiguration("concertRankings", rankingConfig)
+            .build();
+}
+
+// DTO에 Serializable 추가
+record ConcertRankingDto(
+        int rank,
+        Long scheduleId,
+        String concertName,
+        int soldCount,
+        double velocityPerMinute,
+        boolean isSoldOut,
+        Integer soldOutSeconds
+) implements Serializable {}
+```
+
+`JdkSerializationRedisSerializer`로 변경하고 DTO에 `Serializable`을 구현해서 타입 안전성을 보장했다.
+
+아 죄송해요! 실제 구현된 전체 코드를 제대로 반영해서 다시 작성할게요.
+
+---
+
+#### 문제 2. N+1 문제 발견과 배치 조회
+
+**상황:**
+
+처음엔 랭킹 조회 시 for문 안에서 각 스케줄마다 DB를 조회했다.
+
+```java
+// Before: for문 안에서 매번 DB 조회
+for (String scheduleKey : topSchedules) {
+    Long scheduleId = extractScheduleId(scheduleKey);
+    
+    // 매번 DB 쿼리 발생! (N+1)
+    Optional<ConcertSchedule> schedule = schedulePort.findById(scheduleId);
+    String concertName = schedule.map(s -> "Concert #" + scheduleId).orElse("Unknown");
+    // ...
+}
+```
+
+10개 랭킹이면 DB 쿼리 10번, 100개면 100번...
+
+**해결: 3단계 조회 전략**
+
+```java
+@Override
+@Cacheable(value = "concertRankings", key = "#limit")
+public List<ConcertRankingDto> getFastSellingRanking(int limit) {
+    log.debug("랭킹 조회 - Port를 통한 데이터 조회 (캐시 미스)");
+    
+    Set<String> topSchedules = rankingPort.getTopByVelocity(limit);
+    
+    if (topSchedules.isEmpty()) {
+        return List.of();
+    }
+    
+    // 1. scheduleId 목록 추출
+    List<Long> scheduleIds = topSchedules.stream()
+            .map(this::extractScheduleId)
+            .filter(Objects::nonNull)
+            .toList();
+    
+    // 2. 배치로 한 번에 조회 - 핵심!
+    Map<Long, ConcertSchedule> scheduleMap = schedulePort.findAllByIds(scheduleIds);
+    
+    // 3. 랭킹 데이터 조합
+    List<ConcertRankingDto> result = new ArrayList<>();
+    int rank = 1;
+    
+    for (String scheduleKey : topSchedules) {
+        try {
+            Long scheduleId = extractScheduleId(scheduleKey);
+            if (scheduleId == null) continue;
+            
+            Map<String, String> stats = rankingPort.getStats(String.valueOf(scheduleId));
+            if (stats.isEmpty()) continue;
+            
+            // 통계 정보 추출
+            int soldCount = getIntValue(stats.get("soldCount"));
+            double velocity = calculateVelocity(stats);
+            boolean isSoldOut = stats.containsKey("soldOutTime");
+            Integer soldOutSeconds = isSoldOut ?
+                    getIntValue(stats.get("soldOutSeconds")) : null;
+            
+            // Map에서 O(1) 조회 - DB 쿼리 없음!
+            String concertName = Optional.ofNullable(scheduleMap.get(scheduleId))
+                    .map(schedule -> "Concert #" + scheduleId)
+                    .orElse("Unknown Concert #" + scheduleId);
+            
+            result.add(new ConcertRankingDto(
+                    rank++,
+                    scheduleId,
+                    concertName,
+                    soldCount,
+                    velocity,
+                    isSoldOut,
+                    soldOutSeconds
+            ));
+            
+        } catch (NumberFormatException e) {
+            log.warn("숫자 형식 오류 - scheduleKey: {}", scheduleKey);
+        } catch (Exception e) {
+            log.error("랭킹 항목 처리 실패 - scheduleKey: {}", scheduleKey, e);
+        }
+    }
+    
+    return result;
+}
+```
+
+**개선 효과**
+```
+Before: SELECT * FROM schedule WHERE id = 1;
+        SELECT * FROM schedule WHERE id = 2;
+        ...
+        SELECT * FROM schedule WHERE id = 10;
+        → 10번 쿼리
+
+After:  SELECT * FROM schedule WHERE id IN (1,2,...,10);
+        → 1번 쿼리
+```
+
+**배운 점**
+- 일단 동작하게 만들고, 성능 테스트 중에 문제 발견
+- `findAllByIds()`로 배치 조회 → Map으로 변환
+- 예외 처리로 일부 실패해도 전체는 성공
+
+---
+
+#### 문제 3. 성능 측정의 어려움
+
+**초기 코드**
+```java
+long start = System.currentTimeMillis();
+service.getFastSellingRanking(10);
+long time = System.currentTimeMillis() - start;
+```
+
+**문제점**
+- 1ms vs 1ms 비교 → 측정 오차 범위
+- 캐시 히트가 오히려 더 느리게 측정되기도 함
+- JVM Hotspot 최적화 전에 측정
+
+**해결**
+```java
+// RankingCachePerformanceTest.java
+@Test
+@DisplayName("100회 조회 성능 - 캐싱 효과")
+void test_100회_조회_캐싱_효과() {
+    // Given: 랭킹 데이터 준비
+    for (int i = 1; i <= 20; i++) {
+        rankingUseCase.trackReservation((long) i, i * 3);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        rankingUseCase.getFastSellingRanking(10);
+    }
+
+    // When: 100회 조회 (모두 캐시 히트여야 함)
+    long start = System.nanoTime();
+    for (int i = 0; i < 100; i++) {
+        rankingUseCase.getFastSellingRanking(10);
+    }
+    long totalTime = System.nanoTime() - start;
+
+    double avgTimeMs = totalTime / 100.0 / 1_000_000.0;
+    long totalTimeMs = totalTime / 1_000_000;
+
+    log.info("=== 100회 조회 성능 ===");
+    log.info("총 소요 시간: {}ms", totalTimeMs);
+    log.info("평균 응답 시간: {}ms", avgTimeMs);
+    log.info("TPS: {} req/s", 100_000.0 / totalTimeMs);
+
+    assertThat(avgTimeMs).isLessThan(3.0);  // 3ms 이내 (캐시 히트 기준)
+    assertThat(totalTimeMs).isLessThan(300);  // 전체 300ms 이내
+}
+```
+
+**개선 사항**
+1. **JVM Warmup**: 10회 사전 실행으로 Hotspot 최적화
+2. **100회 반복**: 통계적으로 신뢰할 수 있는 데이터
+3. **나노초 단위**: `System.nanoTime()` 사용
+
+**결과**
+```
+100회 평균 응답 시간: 0.2ms
+TPS: 2,000+ req/s
+```
+
+---
+
+## 2. Asynchronous Design - Redis 대기열 시스템
+
+### 2.1 핵심 구현
+
+#### 원자적 카운터로 동시성 제어
+
+```java
+// RedisQueueAdapter.java
+@Override
+public QueueToken issue(String userId) {
+    // 기존 토큰 확인
+    String existingToken = redisTemplate.opsForValue().get(USER_TOKEN_MAP + userId);
+    if (existingToken != null && isValidToken(existingToken)) {
+        return new QueueToken(existingToken);
+    }
+
+    // 새 토큰 생성
+    String token = UUID.randomUUID().toString();
+    long timestamp = Instant.now().toEpochMilli();
+
+    // 토큰 정보 저장
+    saveTokenInfo(token, userId, timestamp);
+    redisTemplate.opsForValue().set(USER_TOKEN_MAP + userId, token, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+
+    // 원자적 카운터로 동시성 제어
+    Long currentCount = redisTemplate.opsForValue().increment("queue:active:counter");
+
+    if (currentCount != null && currentCount <= MAX_ACTIVE_USERS) {
+        // 100명 이내면 활성화
+        activateToken(token);
+        log.info("토큰 발급 완료: userId={}, activated=true", userId);
+    } else {
+        // 초과하면 카운터 롤백하고 대기열 추가
+        redisTemplate.opsForValue().decrement("queue:active:counter");
+        redisTemplate.opsForZSet().add(WAITING_QUEUE, token, (double) timestamp);
+        redisTemplate.opsForHash().put(TOKEN_INFO + token, "status", "WAITING");
+        log.info("토큰 발급 완료: userId={}, activated=false", userId);
+    }
+
+    return new QueueToken(token);
+}
+```
+
+**핵심 아이디어**
+- Redis의 `increment/decrement`는 원자적 연산
+- 분산락 없이도 동시성 제어 가능
+- 초과 시 즉시 롤백하여 정확한 카운트 유지
+
+#### Redis 자료구조 활용
+
+```java
+private static final String WAITING_QUEUE = "queue:waiting";
+private static final String ACTIVE_SET = "queue:active";
+private static final String TOKEN_INFO = "queue:token:";
+private static final String USER_TOKEN_MAP = "queue:user:";
+private static final String LOCK_ACTIVATE = "lock:queue:activate";
+
+private static final int MAX_ACTIVE_USERS = 100;
+private static final int TOKEN_TTL_MINUTES = 10;
+
+// 대기 순번 조회
+@Override
+public Long getWaitingPosition(String token) {
+    Long rank = redisTemplate.opsForZSet().rank(WAITING_QUEUE, token);
+    return rank != null ? rank + 1 : null;
+}
+
+// 대기열에서 활성화
+@Override
+public void activateNextUsers(int count) {
+    if (count <= 0) return;
+
+    try {
+        distributedLock.executeWithLock(
+                LOCK_ACTIVATE, 10, 3, 200,
+                () -> {
+                    cleanupExpiredTokens();
+
+                    Long activeCount = getActiveCount();
+                    int availableSlots = MAX_ACTIVE_USERS - activeCount.intValue();
+                    if (availableSlots <= 0) return null;
+
+                    int toActivate = Math.min(count, availableSlots);
+                    Set<String> tokens = redisTemplate.opsForZSet().range(WAITING_QUEUE, 0, toActivate - 1);
+
+                    if (tokens != null && !tokens.isEmpty()) {
+                        tokens.forEach(this::activateToken);
+                        log.info("대기열 활성화: {}명", tokens.size());
+                    }
+                    return null;
+                }
+        );
+    } catch (Exception e) {
+        log.error("대기열 활성화 실패", e);
+    }
+}
+```
+
+**선택한 자료구조**
+- **Sorted Set** (대기열): 타임스탬프를 score로 사용, FIFO 보장
+- **Set** (활성 사용자): O(1) 존재 여부 확인
+- **Hash** (토큰 정보): userId, status, issuedAt 저장
+- **String** (원자적 카운터): increment/decremnt로 동시성 제어
+
+#### 분산락 활용
+
+```java
+// RedisDistributedLock.java
+public <T> T executeWithLock(
+        String lockKey,
+        long ttlSeconds,
+        int retryCount,
+        long retryDelayMillis,
+        Supplier<T> action
+) {
+    String lockValue = UUID.randomUUID().toString();
+    int attempts = 0;
+
+    while (attempts < retryCount) {
+        boolean acquired = tryLock(lockKey, lockValue, ttlSeconds);
+
+        if (acquired) {
+            try {
+                log.info("락 획득 성공: key={}, value={}", lockKey, lockValue);
+                return action.get();
+            } finally {
+                // unlock 호출 제거 - TTL로 자동 만료
+                // unlock의 race condition을 피하기 위해 명시적 해제를 하지 않음
+                log.info("락은 TTL({}초)로 자동 만료됨: key={}", ttlSeconds, lockKey);
+            }
+        }
+
+        attempts++;
+        if (attempts < retryCount) {
+            log.info("락 획득 실패, 재시도 {}/{}: key={}", attempts, retryCount, lockKey);
+            sleep(retryDelayMillis);
+        }
+    }
+
+    throw LockAcquisitionException.of(lockKey, retryCount);
+}
+```
+
+**설계 포인트**
+- `setIfAbsent(key, value, Duration)` 사용
+- unlock 메서드 제거 → TTL 자동 만료 방식
+- Race Condition 방지
+
+### 2.2 겪었던 문제들
+
+#### 문제 1. unlock의 Race Condition
+
+**초기 구현:**
+```java
+public boolean unlock(String key, String value) {
+    String currentValue = redisTemplate.opsForValue().get(key);
+    
+    // 내 락인지 확인 후 삭제
+    if (value.equals(currentValue)) {
+        redisTemplate.delete(key);
+        return true;
+    }
+    return false;
+}
+```
+
+**문제 시나리오:**
+```
+Thread A: get(lock) → "my-value"
+Thread A: 비교 성공
+[이 사이에 TTL 만료!]
+Thread B: 새로운 락 획득
+Thread A: delete → Thread B의 락까지 삭제!
+```
+
+**해결 선택지 비교:**
+
+| 방식 | 장점 | 단점 |
+|------|------|------|
+| Lua 스크립트 | 완벽한 원자성 보장 | 복잡도 증가, 디버깅 어려움 |
+| TTL 자동 만료 | 코드 단순, 이해 쉬움 | TTL > 처리시간 보장 필요 |
+
+**선택:**
+- 우리 처리 시간: ~1초
+- TTL 설정: 10초
+- 10배 여유 → TTL 자동 만료 선택
+- 추후 처리 시간이 길어지면 Lua 도입 고려
+
+
+#### 문제 2. 테스트 격리 실패
+
+**상황**
+```
+Test 1 실행: 100명 활성화 ✓
+Test 2 실행: 대기 순번 1번 예상 → 실제 135번!
+```
+
+개별 테스트는 성공하는데 전체 실행하면 실패했다.
+
+**원인**
+- Testcontainers로 Redis를 띄워도 데이터는 테스트 간 유지됨
+- `@DirtiesContext`는 ApplicationContext만 재시작
+- Redis 데이터는 그대로 남아있음
+
+**해결**
+```java
+// CachePerformanceTest.java
+@BeforeEach
+void setUp() {
+    // Redis 완전 클리어 (flushDb 사용)
+    try {
+        Objects.requireNonNull(redisTemplate.getConnectionFactory())
+                .getConnection()
+                .serverCommands()
+                .flushDb();  // flushAll 대신 flushDb
+    } catch (Exception e) {
+        log.warn("Redis flush 실패: {}", e.getMessage());
+    }
+
+    // 약간 대기 (Redis 정리 완료 대기)
+    try {
+        Thread.sleep(100);
+    } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+    }
+
+    // 캐시 이름 동적으로 클리어
+    cacheManager.getCacheNames().forEach(cacheName -> {
+        try {
+            var cache = cacheManager.getCache(cacheName);
+            if (cache != null) {
+                cache.clear();
+                log.debug("캐시 클리어: {}", cacheName);
+            }
+        } catch (Exception e) {
+            log.warn("캐시 클리어 실패: {} - {}", cacheName, e.getMessage());
+        }
+    });
+
+    // 테스트 데이터 준비
+    testDate = LocalDate.now().plusDays(1);
+
+    ConcertJpaEntity concert = new ConcertJpaEntity("캐시 테스트용 콘서트");
+    concert = concertRepository.save(concert);
+    testConcertId = concert.getId();
+
+    ConcertScheduleJpaEntity schedule = new ConcertScheduleJpaEntity(
+            concert,
+            testDate,
+            50
+    );
+    scheduleRepository.save(schedule);
+
+    log.info("테스트 준비 완료 - concertId: {}, date: {}", testConcertId, testDate);
+}
+```
+
+명시적으로 `flushDb()`를 호출하고 100ms 대기하여 해결했다.
+
+
+#### 문제 3. 150명 동시 테스트 성공!
+
+**테스트 시나리오:**
+```java
+@Test
+void concurrentIssue() throws InterruptedException {
+    int totalUsers = 150;
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch endLatch = new CountDownLatch(totalUsers);
+    ExecutorService executor = Executors.newFixedThreadPool(50);
+    
+    // 150명이 동시에 토큰 발급 요청
+    for (int i = 1; i <= totalUsers; i++) {
+        executor.submit(() -> {
+            startLatch.await();  // 모두 대기
+            QueueToken token = queuePort.issue(userId);
+            // ...
+            endLatch.countDown();
+        });
+    }
+    
+    startLatch.countDown();  // 동시 시작!
+    endLatch.await(15, TimeUnit.SECONDS);
+}
+```
+
+**결과:**
+```
+총 요청: 150명
+활성화 성공: 100명 ✓
+대기열 추가: 50명 ✓
+소요 시간: 2~3초
+```
+
+**검증된 것:**
+- 원자적 카운터만으로 정확히 100명 제어 가능
+- 분산락 없이도 동시성 제어 성공
+- CountDownLatch로 "진짜 동시" 요청 시뮬레이션
+
+처음엔 "진짜 동시에 요청하는 테스트"를 어떻게 만들지 막막했는데, CountDownLatch가 정답이었다!
+
+---
+
+## 3. 회고
+
+### 3.1 측정의 중요성
+
+처음엔 캐시를 적용하면 당연히 빨라질 거라고 생각했다. 그런데 막상 테스트를 돌려보니 둘 다 1ms였다. 왜 빨라지지 않을지 한참을 고민했다. 문제는 내가 제대로 측정하지 못하고 있는 것이었다.
+
+JVM Warmup이 필요하다는 것도, `System.currentTimeMillis()`가 아니라 `System.nanoTime()`을 써야 한다는 것도, 한 번이 아니라 100번 반복해서 통계를 내야 한다는 것도 이번에 처음 알았다.
+
+Warmup 후 제대로 측정하니까 캐시 효과가 명확하게 보였다. 측정 결과 10배 정도는 빨라졌다.
+
+### 3.2 분산락의 unlock 구현
+
+이번 과제에서 가장 고민했던 부분은 분산락의 unlock 구현이었다.
+
+**선택지 1: Lua 스크립트**
+- 완벽한 원자성 보장
+- 팀원들이 Lua에 대한 이해도가 높지 않다면 이해 및 유지보수 어려움
+
+**선택지 2: TTL 자동 만료**
+- 코드가 단순하고 이해하기 쉬움
+- 하지만 처리 시간이 TTL을 초과하면 문제 가능성
+
+이미 Lua 스크립트는 지양하는 게 좋다는 피드백을 받았었기도 했고, 우리 시나리오에서는 처리 시간이 1초도 안 걸릴 것이라고 생각했기 때문에 TTL 방식을 선택했다.
+
+### 3.3 동시성 문제
+
+이론으로 배울 때는 Race Condition을 막으려면 단순히 락을 걸면 될거라고 생각했다. 근데 막상 구현해보니 그게 아니었다.
+
+- 어디서부터 어디까지 락을 걸어야 하나?
+- 트랜잭션과 락의 순서는?
+- TaskExecutor의 큐 크기도 고려해야 하나?
+- unlock의 get-check-delete도 Race Condition이 생기네?
+
+하나하나가 다 고민거리였다. 특히 TaskExecutor Deadlock은 정말 예상 못 한 문제였다. 큐가 꽉 차면 호출 스레드에서 직접 실행한다는 걸 알고 있었지만, 그게 CountDownLatch와 만나면 Deadlock이 된다는 건 생각 못 했다.
+
+동시성 문제는 코드만 봐서는 절대 발견 못하므로 테스트로만 발견 가능하다. 그래서 150명 동시 테스트, 1000명 동시 테스트가 필요헀다.
+
+### 3.4 아쉬운 점
+
+1. 실제 부하 테스트는 못 해봤다. 로컬에서 1000명 동시 테스트까지는 했는데, 실제 프로덕션 환경에서 수만 명이 동시에 들어오면 어떻게 될지는 모르겠다. 추후에 AWS에 배포해서 JMeter로 실제 부하 테스트를 해 보는 게 좋을 것 같다.
+
+2. TTL 자동 만료의 한계가 있을 수 있다. 지금 방식은 처리 시간이 TTL을 넘으면 문제가 생길 수 있다. 네트워크 지연과 같은 문제로 TTL을 넘을 수도 있는데, 그런 엣지 케이스까지는 고려하지 못했다.
+
+### 3.5 느낀점
+
+이번 과제를 하기 전엔 Redis를 제대로 사용해 본 적도 없었는데, 이제는 활용할 수 있게 되었다. 동시성 테스트 검증에도 조금은 익숙해졌고, 캐싱을 적용해 성능 개선을 측정해보기도 했다.
+
+취업 준비를 하면서 내가 할 수 있는 게 많이 없고, 남들보다 뒤쳐진다는 생각에 불안한 마음이 많이 들었었는데, 이제는 기술 면접에서 나도 할 이야기가 생겼다.
+
+아직도 난 많이 부족하고, 완벽하지 않으며, 배워야 하고 고쳐야 하는 것들이 많다. 실수도 많이 하고 헤매는 시간도 길지만 그만큼 성장할 가능성이 크다고 믿고 싶다!
+
+이제 얼마 남지 않은 다음 스텝들이 아쉽기도 하고, 기대도 된다!

--- a/docs/Redis_랭킹_대기열_회고.md
+++ b/docs/Redis_랭킹_대기열_회고.md
@@ -235,8 +235,6 @@ record ConcertRankingDto(
 
 `JdkSerializationRedisSerializer`로 변경하고 DTO에 `Serializable`을 구현해서 타입 안전성을 보장했다.
 
-아 죄송해요! 실제 구현된 전체 코드를 제대로 반영해서 다시 작성할게요.
-
 ---
 
 #### 문제 2. N+1 문제 발견과 배치 조회

--- a/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.application.port.in;
+
+import java.util.List;
+
+public interface RankingUseCase {
+
+    // 판매 추적
+    void trackReservation(Long scheduleId, int seatCount);
+
+    // 랭킹 조회
+    List<FastSellingDto> getFastSellingRanking(int limit);
+    List<SoldOutRankingDto> getFastestSoldOutRanking(int limit);
+
+    // DTO는 여기 내부 클래스로 정의해도 됨
+    record FastSellingDto(
+            int rank,
+            Long scheduleId,
+            String concertName,
+            double velocityPerMinute
+    ) {}
+
+    record SoldOutRankingDto(
+            int rank,
+            Long scheduleId,
+            String concertName,
+            int soldOutSeconds,
+            String formattedTime
+    ) {}
+}

--- a/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
@@ -1,5 +1,6 @@
 package kr.hhplus.be.server.application.port.in;
 
+import java.io.Serializable;
 import java.util.List;
 
 public interface RankingUseCase {
@@ -19,5 +20,5 @@ public interface RankingUseCase {
             double velocityPerMinute,
             boolean isSoldOut,
             Integer soldOutSeconds
-    ) {}
+    ) implements Serializable {}
 }

--- a/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
@@ -4,26 +4,20 @@ import java.util.List;
 
 public interface RankingUseCase {
 
-    // 판매 추적
+    // 예약 추적
     void trackReservation(Long scheduleId, int seatCount);
 
-    // 랭킹 조회
-    List<FastSellingDto> getFastSellingRanking(int limit);
-    List<SoldOutRankingDto> getFastestSoldOutRanking(int limit);
+    // 빠른 판매 랭킹 조회
+    List<ConcertRankingDto> getFastSellingRanking(int limit);
 
-    // DTO는 여기 내부 클래스로 정의해도 됨
-    record FastSellingDto(
+    // 통합 랭킹 DTO
+    record ConcertRankingDto(
             int rank,
             Long scheduleId,
             String concertName,
-            double velocityPerMinute
-    ) {}
-
-    record SoldOutRankingDto(
-            int rank,
-            Long scheduleId,
-            String concertName,
-            int soldOutSeconds,
-            String formattedTime
+            int soldCount,
+            double velocityPerMinute,
+            boolean isSoldOut,
+            Integer soldOutSeconds
     ) {}
 }

--- a/src/main/java/kr/hhplus/be/server/application/port/out/ConcertSchedulePort.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/out/ConcertSchedulePort.java
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.domain.concert.ConcertSchedule;
 import kr.hhplus.be.server.domain.concert.ConcertScheduleId;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface ConcertSchedulePort {
@@ -20,6 +21,8 @@ public interface ConcertSchedulePort {
     // 사용 가능한 날짜 목록 조회
     List<LocalDate> findAvailableDates(int days);
 
-    // 스케줄 저장 (필요시)
+    // 스케줄 저장
     ConcertSchedule save(ConcertSchedule schedule);
+
+    Map<Long, ConcertSchedule> findAllByIds(List<Long> ids);
 }

--- a/src/main/java/kr/hhplus/be/server/application/port/out/RankingPort.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/out/RankingPort.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.application.port.out;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface RankingPort {
+    // Redis 연산 추상화
+    void saveStats(String scheduleId, Map<String, String> stats);
+    Map<String, String> getStats(String scheduleId);
+    void updateVelocityRanking(String scheduleId, double score);
+    void updateSoldOutRanking(String scheduleId, long seconds);
+    Set<String> getTopByVelocity(int limit);
+    Set<String> getTopBySoldOut(int limit);
+}

--- a/src/main/java/kr/hhplus/be/server/application/port/out/RankingPort.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/out/RankingPort.java
@@ -4,11 +4,27 @@ import java.util.Map;
 import java.util.Set;
 
 public interface RankingPort {
-    // Redis 연산 추상화
+    // 통계 저장
     void saveStats(String scheduleId, Map<String, String> stats);
+
+    // 통계 조회
     Map<String, String> getStats(String scheduleId);
+
+    // 판매 수량 증가
+    long incrementSoldCount(String scheduleId, int increment);
+
+    // 첫 판매 시간 설정
+    boolean setStartTimeIfAbsent(String scheduleId, long startTime);
+
+    // 판매 속도 랭킹 업데이트
     void updateVelocityRanking(String scheduleId, double score);
+
+    // 매진 랭킹 업데이트
     void updateSoldOutRanking(String scheduleId, long seconds);
+
+    // 판매 속도 기준 상위 랭킹 조회
     Set<String> getTopByVelocity(int limit);
+
+    // 매진 속도 기준 상위 랭킹 조회
     Set<String> getTopBySoldOut(int limit);
 }

--- a/src/main/java/kr/hhplus/be/server/application/service/ConcertRankingService.java
+++ b/src/main/java/kr/hhplus/be/server/application/service/ConcertRankingService.java
@@ -2,12 +2,10 @@ package kr.hhplus.be.server.application.service;
 
 import kr.hhplus.be.server.application.port.in.RankingUseCase;
 import kr.hhplus.be.server.application.port.out.ConcertSchedulePort;
-import kr.hhplus.be.server.application.port.out.RankingPort;
 import kr.hhplus.be.server.domain.concert.ConcertSchedule;
 import kr.hhplus.be.server.domain.concert.ConcertScheduleId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
@@ -15,7 +13,6 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.WeekFields;
 import java.util.*;
 
 @Service
@@ -23,18 +20,15 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ConcertRankingService implements RankingUseCase {
 
-    private final RankingPort rankingPort;
     private final ConcertSchedulePort schedulePort;
     private final RedisTemplate<String, String> redisTemplate;
 
     // Redis Key 상수
-    private static final String VELOCITY_PREFIX = "ranking:velocity:";
-    private static final String SOLDOUT_RANKING = "ranking:soldout:fastest";
+    private static final String VELOCITY_RANKING = "ranking:velocity";  // 단일 랭킹
     private static final String SCHEDULE_STATS = "stats:schedule:";
-    private static final String TEMP_RANKING = "temp:ranking:";
 
     // 설정 값
-    private static final int DEFAULT_TOTAL_SEATS = 100;  // 기본 좌석 수
+    private static final int DEFAULT_TOTAL_SEATS = 100;
 
     /**
      * 예약 확정 시 호출 - 판매 속도 추적
@@ -43,22 +37,33 @@ public class ConcertRankingService implements RankingUseCase {
     public void trackReservation(Long scheduleId, int seatCount) {
         String statsKey = SCHEDULE_STATS + scheduleId;
 
-        // 첫 판매 시간 기록 (존재하지 않을 때만)
-        Boolean isFirst = redisTemplate.opsForHash()
-                .putIfAbsent(statsKey, "startTime", String.valueOf(System.currentTimeMillis()));
+        // 매진 체크 (매진이면 더 이상 집계하지 않음)
+        Boolean isSoldOut = redisTemplate.opsForHash().hasKey(statsKey, "soldOutTime");
+        if (Boolean.TRUE.equals(isSoldOut)) {
+            log.debug("이미 매진된 공연 - scheduleId: {}", scheduleId);
+            return;
+        }
+
+        // 첫 판매 시간 기록
+        redisTemplate.opsForHash().putIfAbsent(statsKey, "startTime",
+                String.valueOf(System.currentTimeMillis()));
 
         // 판매 수량 누적
-        redisTemplate.opsForHash().increment(statsKey, "soldCount", seatCount);
+        Long newSoldCount = redisTemplate.opsForHash().increment(statsKey, "soldCount", seatCount);
 
-        // 현재 시각 업데이트 (마지막 판매 시각)
+        // 현재 시간 업데이트
         redisTemplate.opsForHash().put(statsKey, "lastSaleTime",
                 String.valueOf(System.currentTimeMillis()));
+
+        log.debug("예약 추적 - scheduleId: {}, 추가: {}석, 누적: {}석", scheduleId, seatCount, newSoldCount);
 
         // 판매 속도 계산 및 랭킹 업데이트
         updateVelocityRanking(scheduleId);
 
         // 매진 체크
-        checkAndRecordSoldOut(scheduleId);
+        if (newSoldCount >= DEFAULT_TOTAL_SEATS) {
+            recordSoldOut(scheduleId);
+        }
     }
 
     /**
@@ -70,7 +75,6 @@ public class ConcertRankingService implements RankingUseCase {
 
         if (stats.isEmpty()) return;
 
-        // 판매 시작 후 경과 시간과 판매량 계산
         long startTime = Long.parseLong((String) stats.get("startTime"));
         Object soldCountObj = stats.get("soldCount");
         long soldCount = soldCountObj instanceof Long ?
@@ -78,142 +82,22 @@ public class ConcertRankingService implements RankingUseCase {
 
         // 경과 시간 (분 단위)
         long elapsedMinutes = (System.currentTimeMillis() - startTime) / 60000;
-        if (elapsedMinutes < 1) elapsedMinutes = 1;  // 최소 1분
+        if (elapsedMinutes < 1) elapsedMinutes = 1;
 
         // 분당 판매량 = 판매 속도
         double velocity = soldCount / (double) elapsedMinutes;
 
-        // 시간별 키 사용
-        String hourKey = VELOCITY_PREFIX + getCurrentHour();
-
         // Sorted Set 업데이트 (높은 점수 = 빠른 판매)
-        redisTemplate.opsForZSet().add(hourKey, "schedule:" + scheduleId, velocity);
-
-        // 이 시간대 키만 3시간 후 만료
-        redisTemplate.expire(hourKey, Duration.ofHours(3));
+        redisTemplate.opsForZSet().add(VELOCITY_RANKING, "schedule:" + scheduleId, velocity);
 
         log.debug("판매 속도 업데이트 - scheduleId: {}, velocity: {:.2f} tickets/min",
                 scheduleId, velocity);
     }
 
     /**
-     * 빠른 판매 랭킹 조회 (판매 중인 공연)
+     * 매진 기록
      */
-    @Override
-    public List<FastSellingDto> getFastSellingRanking(int limit) {
-        // 최근 2시간 데이터 합산
-        String currentHour = getCurrentHour();
-        String previousHour = getPreviousHour();
-
-        Set<String> keys = Set.of(
-                VELOCITY_PREFIX + currentHour,
-                VELOCITY_PREFIX + previousHour
-        );
-
-        // 임시 키로 Union 수행
-        String tempKey = TEMP_RANKING + UUID.randomUUID();
-
-        try {
-            // 여러 시간대 데이터를 합산
-            redisTemplate.opsForZSet().unionAndStore(
-                    null,  // 첫 번째 키
-                    keys,  // 합칠 키들
-                    tempKey
-            );
-
-            // 임시 키 짧은 TTL 설정
-            redisTemplate.expire(tempKey, Duration.ofSeconds(10));
-
-            // 상위 N개 조회 (높은 점수 순)
-            Set<ZSetOperations.TypedTuple<String>> rankings =
-                    redisTemplate.opsForZSet().reverseRangeWithScores(tempKey, 0, limit - 1);
-
-            if (rankings == null || rankings.isEmpty()) {
-                return List.of();
-            }
-
-            // DTO 변환
-            List<FastSellingDto> result = new ArrayList<>();
-            int rank = 1;
-
-            for (ZSetOperations.TypedTuple<String> tuple : rankings) {
-                Long scheduleId = extractScheduleId(tuple.getValue());
-                String concertName = getConcertName(scheduleId);
-
-                result.add(new FastSellingDto(
-                        rank++,
-                        scheduleId,
-                        concertName,
-                        tuple.getScore() != null ? tuple.getScore() : 0.0
-                ));
-            }
-
-            return result;
-
-        } finally {
-            // 임시 키 정리
-            redisTemplate.delete(tempKey);
-        }
-    }
-
-    /**
-     * 매진 속도 랭킹 조회 (빠르게 매진된 공연)
-     */
-    @Override
-    public List<SoldOutRankingDto> getFastestSoldOutRanking(int limit) {
-        // 낮은 값이 더 빠른 매진 (초 단위)
-        Set<ZSetOperations.TypedTuple<String>> rankings =
-                redisTemplate.opsForZSet().rangeWithScores(SOLDOUT_RANKING, 0, limit - 1);
-
-        if (rankings == null || rankings.isEmpty()) {
-            return List.of();
-        }
-
-        List<SoldOutRankingDto> result = new ArrayList<>();
-        int rank = 1;
-
-        for (ZSetOperations.TypedTuple<String> tuple : rankings) {
-            Long scheduleId = extractScheduleId(tuple.getValue());
-            String concertName = getConcertName(scheduleId);
-            int seconds = tuple.getScore() != null ? tuple.getScore().intValue() : 0;
-
-            result.add(new SoldOutRankingDto(
-                    rank++,
-                    scheduleId,
-                    concertName,
-                    seconds,
-                    formatDuration(seconds)
-            ));
-        }
-
-        return result;
-    }
-
-    /**
-     * 매진 확인 및 기록
-     */
-    private void checkAndRecordSoldOut(Long scheduleId) {
-        // 전체 좌석 수 조회
-        Integer totalSeats = getTotalSeats(scheduleId);
-
-        String statsKey = SCHEDULE_STATS + scheduleId;
-        Object soldCountObj = redisTemplate.opsForHash().get(statsKey, "soldCount");
-
-        if (soldCountObj == null) return;
-
-        long soldCount = soldCountObj instanceof Long ?
-                (Long) soldCountObj : Long.parseLong(soldCountObj.toString());
-
-        // 매진 확인
-        if (soldCount >= totalSeats) {
-            recordSoldOutTime(scheduleId);
-        }
-    }
-
-    /**
-     * 매진 시간 기록
-     */
-    private void recordSoldOutTime(Long scheduleId) {
+    private void recordSoldOut(Long scheduleId) {
         String statsKey = SCHEDULE_STATS + scheduleId;
 
         // 이미 매진 기록이 있는지 확인
@@ -226,64 +110,69 @@ public class ConcertRankingService implements RankingUseCase {
 
         long startTime = Long.parseLong(startTimeStr);
         long soldOutTime = System.currentTimeMillis();
-
-        // 매진 소요 시간 (초 단위)
         long durationSeconds = (soldOutTime - startTime) / 1000;
 
         // 매진 정보 저장
         redisTemplate.opsForHash().put(statsKey, "soldOutTime", String.valueOf(soldOutTime));
-        redisTemplate.opsForHash().put(statsKey, "soldOutDuration", String.valueOf(durationSeconds));
+        redisTemplate.opsForHash().put(statsKey, "soldOutSeconds", String.valueOf(durationSeconds));
 
-        // 매진 속도 랭킹 추가 (낮은 값이 더 빠름)
-        redisTemplate.opsForZSet().add(SOLDOUT_RANKING,
-                "schedule:" + scheduleId, durationSeconds);
+        log.info("🎉 매진 기록 - scheduleId: {}, 소요 시간: {}초", scheduleId, durationSeconds);
+    }
 
-        // 주간 매진 랭킹도 추가
-        String weeklyKey = "ranking:soldout:weekly:" + getCurrentWeek();
-        redisTemplate.opsForZSet().add(weeklyKey,
-                "schedule:" + scheduleId, durationSeconds);
-        redisTemplate.expire(weeklyKey, Duration.ofDays(14));  // 2주 보관
+    /**
+     * 빠른 판매 랭킹 조회 (통합)
+     */
+    @Override
+    public List<ConcertRankingDto> getFastSellingRanking(int limit) {
+        // 높은 점수 순으로 조회 (빠른 판매 순)
+        Set<ZSetOperations.TypedTuple<String>> rankings =
+                redisTemplate.opsForZSet().reverseRangeWithScores(VELOCITY_RANKING, 0, limit - 1);
 
-        log.info("🎉 매진 기록 - scheduleId: {}, 소요시간: {}초", scheduleId, durationSeconds);
+        if (rankings == null || rankings.isEmpty()) {
+            return List.of();
+        }
 
-        // 현재 시간대의 판매 속도 랭킹에서 제거
-        String currentHourKey = VELOCITY_PREFIX + getCurrentHour();
-        redisTemplate.opsForZSet().remove(currentHourKey, "schedule:" + scheduleId);
+        List<ConcertRankingDto> result = new ArrayList<>();
+        int rank = 1;
+
+        for (ZSetOperations.TypedTuple<String> tuple : rankings) {
+            try {
+                Long scheduleId = extractScheduleId(tuple.getValue());
+                if (scheduleId == null) continue;
+
+                String statsKey = SCHEDULE_STATS + scheduleId;
+                Map<Object, Object> stats = redisTemplate.opsForHash().entries(statsKey);
+
+                if (stats.isEmpty()) continue;
+
+                // 통계 정보 추출
+                int soldCount = getIntValue(stats.get("soldCount"));
+                double velocity = tuple.getScore() != null ? tuple.getScore() : 0.0;
+                boolean isSoldOut = stats.containsKey("soldOutTime");
+                Integer soldOutSeconds = isSoldOut ? getIntValue(stats.get("soldOutSeconds")) : null;
+
+                String concertName = getConcertName(scheduleId);
+
+                result.add(new ConcertRankingDto(
+                        rank++,
+                        scheduleId,
+                        concertName,
+                        soldCount,
+                        velocity,
+                        isSoldOut,
+                        soldOutSeconds
+                ));
+
+            } catch (Exception e) {
+                log.error("랭킹 항목 처리 실패 - tuple: {}", tuple, e);
+            }
+        }
+
+        return result;
     }
 
     // === Helper Methods ===
 
-    /**
-     * 현재 시간 키 생성 (YYYYMMDDHH 형식)
-     */
-    private String getCurrentHour() {
-        return LocalDateTime.now()
-                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
-    }
-
-    /**
-     * 이전 시간 키 생성
-     */
-    private String getPreviousHour() {
-        return LocalDateTime.now()
-                .minusHours(1)
-                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
-    }
-
-    /**
-     * 현재 주차 키 생성 (YYYY-WXX 형식)
-     */
-    private String getCurrentWeek() {
-        LocalDateTime now = LocalDateTime.now();
-        WeekFields weekFields = WeekFields.of(Locale.getDefault());
-        int week = now.get(weekFields.weekOfWeekBasedYear());
-        int year = now.getYear();
-        return String.format("%d-W%02d", year, week);
-    }
-
-    /**
-     * schedule:123 형식에서 ID 추출
-     */
     private Long extractScheduleId(String value) {
         if (value == null || !value.startsWith("schedule:")) {
             return null;
@@ -296,9 +185,6 @@ public class ConcertRankingService implements RankingUseCase {
         }
     }
 
-    /**
-     * 콘서트 이름 조회
-     */
     private String getConcertName(Long scheduleId) {
         if (scheduleId == null) {
             return "Unknown";
@@ -309,9 +195,7 @@ public class ConcertRankingService implements RankingUseCase {
                     schedulePort.findById(new ConcertScheduleId(scheduleId));
 
             if (schedule.isPresent()) {
-                // Concert 정보에서 이름을 가져오거나,
-                // 또는 스케줄 정보를 문자열로 표현
-                return "Concert #" + scheduleId;  // 실제로는 concert.getName() 등
+                return "Concert #" + scheduleId;
             }
         } catch (Exception e) {
             log.warn("Failed to get concert name for scheduleId: {}", scheduleId, e);
@@ -320,35 +204,14 @@ public class ConcertRankingService implements RankingUseCase {
         return "Concert #" + scheduleId;
     }
 
-    /**
-     * 전체 좌석 수 조회
-     */
-    private Integer getTotalSeats(Long scheduleId) {
+    private int getIntValue(Object value) {
+        if (value == null) return 0;
+        if (value instanceof Integer) return (Integer) value;
+        if (value instanceof Long) return ((Long) value).intValue();
         try {
-            Optional<ConcertSchedule> schedule =
-                    schedulePort.findById(new ConcertScheduleId(scheduleId));
-
-            if (schedule.isPresent()) {
-                // 실제로는 schedule.getTotalSeats() 같은 메서드
-                return DEFAULT_TOTAL_SEATS;
-            }
-        } catch (Exception e) {
-            log.warn("Failed to get total seats for scheduleId: {}", scheduleId, e);
-        }
-
-        return DEFAULT_TOTAL_SEATS;
-    }
-
-    /**
-     * 시간 포맷팅 (초 → "X분 Y초" 형식)
-     */
-    private String formatDuration(int seconds) {
-        if (seconds < 60) {
-            return seconds + "초";
-        } else if (seconds < 3600) {
-            return String.format("%d분 %d초", seconds / 60, seconds % 60);
-        } else {
-            return String.format("%d시간 %d분", seconds / 3600, (seconds % 3600) / 60);
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException e) {
+            return 0;
         }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/service/ConcertRankingService.java
+++ b/src/main/java/kr/hhplus/be/server/application/service/ConcertRankingService.java
@@ -1,0 +1,354 @@
+package kr.hhplus.be.server.application.service;
+
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.port.out.ConcertSchedulePort;
+import kr.hhplus.be.server.application.port.out.RankingPort;
+import kr.hhplus.be.server.domain.concert.ConcertSchedule;
+import kr.hhplus.be.server.domain.concert.ConcertScheduleId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ConcertRankingService implements RankingUseCase {
+
+    private final RankingPort rankingPort;
+    private final ConcertSchedulePort schedulePort;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // Redis Key 상수
+    private static final String VELOCITY_PREFIX = "ranking:velocity:";
+    private static final String SOLDOUT_RANKING = "ranking:soldout:fastest";
+    private static final String SCHEDULE_STATS = "stats:schedule:";
+    private static final String TEMP_RANKING = "temp:ranking:";
+
+    // 설정 값
+    private static final int DEFAULT_TOTAL_SEATS = 100;  // 기본 좌석 수
+
+    /**
+     * 예약 확정 시 호출 - 판매 속도 추적
+     */
+    @Override
+    public void trackReservation(Long scheduleId, int seatCount) {
+        String statsKey = SCHEDULE_STATS + scheduleId;
+
+        // 첫 판매 시간 기록 (존재하지 않을 때만)
+        Boolean isFirst = redisTemplate.opsForHash()
+                .putIfAbsent(statsKey, "startTime", String.valueOf(System.currentTimeMillis()));
+
+        // 판매 수량 누적
+        redisTemplate.opsForHash().increment(statsKey, "soldCount", seatCount);
+
+        // 현재 시각 업데이트 (마지막 판매 시각)
+        redisTemplate.opsForHash().put(statsKey, "lastSaleTime",
+                String.valueOf(System.currentTimeMillis()));
+
+        // 판매 속도 계산 및 랭킹 업데이트
+        updateVelocityRanking(scheduleId);
+
+        // 매진 체크
+        checkAndRecordSoldOut(scheduleId);
+    }
+
+    /**
+     * 판매 속도 랭킹 업데이트
+     */
+    private void updateVelocityRanking(Long scheduleId) {
+        String statsKey = SCHEDULE_STATS + scheduleId;
+        Map<Object, Object> stats = redisTemplate.opsForHash().entries(statsKey);
+
+        if (stats.isEmpty()) return;
+
+        // 판매 시작 후 경과 시간과 판매량 계산
+        long startTime = Long.parseLong((String) stats.get("startTime"));
+        Object soldCountObj = stats.get("soldCount");
+        long soldCount = soldCountObj instanceof Long ?
+                (Long) soldCountObj : Long.parseLong(soldCountObj.toString());
+
+        // 경과 시간 (분 단위)
+        long elapsedMinutes = (System.currentTimeMillis() - startTime) / 60000;
+        if (elapsedMinutes < 1) elapsedMinutes = 1;  // 최소 1분
+
+        // 분당 판매량 = 판매 속도
+        double velocity = soldCount / (double) elapsedMinutes;
+
+        // 시간별 키 사용
+        String hourKey = VELOCITY_PREFIX + getCurrentHour();
+
+        // Sorted Set 업데이트 (높은 점수 = 빠른 판매)
+        redisTemplate.opsForZSet().add(hourKey, "schedule:" + scheduleId, velocity);
+
+        // 이 시간대 키만 3시간 후 만료
+        redisTemplate.expire(hourKey, Duration.ofHours(3));
+
+        log.debug("판매 속도 업데이트 - scheduleId: {}, velocity: {:.2f} tickets/min",
+                scheduleId, velocity);
+    }
+
+    /**
+     * 빠른 판매 랭킹 조회 (판매 중인 공연)
+     */
+    @Override
+    public List<FastSellingDto> getFastSellingRanking(int limit) {
+        // 최근 2시간 데이터 합산
+        String currentHour = getCurrentHour();
+        String previousHour = getPreviousHour();
+
+        Set<String> keys = Set.of(
+                VELOCITY_PREFIX + currentHour,
+                VELOCITY_PREFIX + previousHour
+        );
+
+        // 임시 키로 Union 수행
+        String tempKey = TEMP_RANKING + UUID.randomUUID();
+
+        try {
+            // 여러 시간대 데이터를 합산
+            redisTemplate.opsForZSet().unionAndStore(
+                    null,  // 첫 번째 키
+                    keys,  // 합칠 키들
+                    tempKey
+            );
+
+            // 임시 키 짧은 TTL 설정
+            redisTemplate.expire(tempKey, Duration.ofSeconds(10));
+
+            // 상위 N개 조회 (높은 점수 순)
+            Set<ZSetOperations.TypedTuple<String>> rankings =
+                    redisTemplate.opsForZSet().reverseRangeWithScores(tempKey, 0, limit - 1);
+
+            if (rankings == null || rankings.isEmpty()) {
+                return List.of();
+            }
+
+            // DTO 변환
+            List<FastSellingDto> result = new ArrayList<>();
+            int rank = 1;
+
+            for (ZSetOperations.TypedTuple<String> tuple : rankings) {
+                Long scheduleId = extractScheduleId(tuple.getValue());
+                String concertName = getConcertName(scheduleId);
+
+                result.add(new FastSellingDto(
+                        rank++,
+                        scheduleId,
+                        concertName,
+                        tuple.getScore() != null ? tuple.getScore() : 0.0
+                ));
+            }
+
+            return result;
+
+        } finally {
+            // 임시 키 정리
+            redisTemplate.delete(tempKey);
+        }
+    }
+
+    /**
+     * 매진 속도 랭킹 조회 (빠르게 매진된 공연)
+     */
+    @Override
+    public List<SoldOutRankingDto> getFastestSoldOutRanking(int limit) {
+        // 낮은 값이 더 빠른 매진 (초 단위)
+        Set<ZSetOperations.TypedTuple<String>> rankings =
+                redisTemplate.opsForZSet().rangeWithScores(SOLDOUT_RANKING, 0, limit - 1);
+
+        if (rankings == null || rankings.isEmpty()) {
+            return List.of();
+        }
+
+        List<SoldOutRankingDto> result = new ArrayList<>();
+        int rank = 1;
+
+        for (ZSetOperations.TypedTuple<String> tuple : rankings) {
+            Long scheduleId = extractScheduleId(tuple.getValue());
+            String concertName = getConcertName(scheduleId);
+            int seconds = tuple.getScore() != null ? tuple.getScore().intValue() : 0;
+
+            result.add(new SoldOutRankingDto(
+                    rank++,
+                    scheduleId,
+                    concertName,
+                    seconds,
+                    formatDuration(seconds)
+            ));
+        }
+
+        return result;
+    }
+
+    /**
+     * 매진 확인 및 기록
+     */
+    private void checkAndRecordSoldOut(Long scheduleId) {
+        // 전체 좌석 수 조회
+        Integer totalSeats = getTotalSeats(scheduleId);
+
+        String statsKey = SCHEDULE_STATS + scheduleId;
+        Object soldCountObj = redisTemplate.opsForHash().get(statsKey, "soldCount");
+
+        if (soldCountObj == null) return;
+
+        long soldCount = soldCountObj instanceof Long ?
+                (Long) soldCountObj : Long.parseLong(soldCountObj.toString());
+
+        // 매진 확인
+        if (soldCount >= totalSeats) {
+            recordSoldOutTime(scheduleId);
+        }
+    }
+
+    /**
+     * 매진 시간 기록
+     */
+    private void recordSoldOutTime(Long scheduleId) {
+        String statsKey = SCHEDULE_STATS + scheduleId;
+
+        // 이미 매진 기록이 있는지 확인
+        if (redisTemplate.opsForHash().hasKey(statsKey, "soldOutTime")) {
+            return;
+        }
+
+        String startTimeStr = (String) redisTemplate.opsForHash().get(statsKey, "startTime");
+        if (startTimeStr == null) return;
+
+        long startTime = Long.parseLong(startTimeStr);
+        long soldOutTime = System.currentTimeMillis();
+
+        // 매진 소요 시간 (초 단위)
+        long durationSeconds = (soldOutTime - startTime) / 1000;
+
+        // 매진 정보 저장
+        redisTemplate.opsForHash().put(statsKey, "soldOutTime", String.valueOf(soldOutTime));
+        redisTemplate.opsForHash().put(statsKey, "soldOutDuration", String.valueOf(durationSeconds));
+
+        // 매진 속도 랭킹 추가 (낮은 값이 더 빠름)
+        redisTemplate.opsForZSet().add(SOLDOUT_RANKING,
+                "schedule:" + scheduleId, durationSeconds);
+
+        // 주간 매진 랭킹도 추가
+        String weeklyKey = "ranking:soldout:weekly:" + getCurrentWeek();
+        redisTemplate.opsForZSet().add(weeklyKey,
+                "schedule:" + scheduleId, durationSeconds);
+        redisTemplate.expire(weeklyKey, Duration.ofDays(14));  // 2주 보관
+
+        log.info("🎉 매진 기록 - scheduleId: {}, 소요시간: {}초", scheduleId, durationSeconds);
+
+        // 현재 시간대의 판매 속도 랭킹에서 제거
+        String currentHourKey = VELOCITY_PREFIX + getCurrentHour();
+        redisTemplate.opsForZSet().remove(currentHourKey, "schedule:" + scheduleId);
+    }
+
+    // === Helper Methods ===
+
+    /**
+     * 현재 시간 키 생성 (YYYYMMDDHH 형식)
+     */
+    private String getCurrentHour() {
+        return LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+
+    /**
+     * 이전 시간 키 생성
+     */
+    private String getPreviousHour() {
+        return LocalDateTime.now()
+                .minusHours(1)
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+
+    /**
+     * 현재 주차 키 생성 (YYYY-WXX 형식)
+     */
+    private String getCurrentWeek() {
+        LocalDateTime now = LocalDateTime.now();
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int week = now.get(weekFields.weekOfWeekBasedYear());
+        int year = now.getYear();
+        return String.format("%d-W%02d", year, week);
+    }
+
+    /**
+     * schedule:123 형식에서 ID 추출
+     */
+    private Long extractScheduleId(String value) {
+        if (value == null || !value.startsWith("schedule:")) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value.substring("schedule:".length()));
+        } catch (NumberFormatException e) {
+            log.warn("Invalid schedule ID format: {}", value);
+            return null;
+        }
+    }
+
+    /**
+     * 콘서트 이름 조회
+     */
+    private String getConcertName(Long scheduleId) {
+        if (scheduleId == null) {
+            return "Unknown";
+        }
+
+        try {
+            Optional<ConcertSchedule> schedule =
+                    schedulePort.findById(new ConcertScheduleId(scheduleId));
+
+            if (schedule.isPresent()) {
+                // Concert 정보에서 이름을 가져오거나,
+                // 또는 스케줄 정보를 문자열로 표현
+                return "Concert #" + scheduleId;  // 실제로는 concert.getName() 등
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get concert name for scheduleId: {}", scheduleId, e);
+        }
+
+        return "Concert #" + scheduleId;
+    }
+
+    /**
+     * 전체 좌석 수 조회
+     */
+    private Integer getTotalSeats(Long scheduleId) {
+        try {
+            Optional<ConcertSchedule> schedule =
+                    schedulePort.findById(new ConcertScheduleId(scheduleId));
+
+            if (schedule.isPresent()) {
+                // 실제로는 schedule.getTotalSeats() 같은 메서드
+                return DEFAULT_TOTAL_SEATS;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get total seats for scheduleId: {}", scheduleId, e);
+        }
+
+        return DEFAULT_TOTAL_SEATS;
+    }
+
+    /**
+     * 시간 포맷팅 (초 → "X분 Y초" 형식)
+     */
+    private String formatDuration(int seconds) {
+        if (seconds < 60) {
+            return seconds + "초";
+        } else if (seconds < 3600) {
+            return String.format("%d분 %d초", seconds / 60, seconds % 60);
+        } else {
+            return String.format("%d시간 %d분", seconds / 3600, (seconds % 3600) / 60);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/concert/jpa/adapter/ConcertScheduleJpaAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/concert/jpa/adapter/ConcertScheduleJpaAdapter.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -49,6 +51,19 @@ public class ConcertScheduleJpaAdapter implements ConcertSchedulePort {
                 .toList();
     }
 
+    /**
+     * 여러 스케줄을 한 번에 조회
+     */
+    @Override
+    public Map<Long, ConcertSchedule> findAllByIds(List<Long> ids) {
+        return repository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(
+                        ConcertScheduleJpaEntity::getId,
+                        this::toDomain
+                ));
+    }
+
     @Override
     public ConcertSchedule save(ConcertSchedule schedule) {
         // 도메인 → JPA 엔티티 변환
@@ -61,7 +76,6 @@ public class ConcertScheduleJpaAdapter implements ConcertSchedulePort {
                             "존재하지 않는 스케줄입니다: " + schedule.getId().value()));
 
             // 필요한 필드 업데이트 (예: 좌석수 변경 등)
-            // entity.setSeatCount(schedule.getTotalSeats());
         } else {
             // 새 엔티티 생성
             ConcertJpaEntity concertEntity = repository.findById(schedule.getConcertId().value())

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/queue/mysql/MySqlQueueAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/queue/mysql/MySqlQueueAdapter.java
@@ -20,7 +20,6 @@ import java.util.UUID;
 
 @Slf4j
 @Component
-@Primary
 @RequiredArgsConstructor
 public class MySqlQueueAdapter implements QueuePort {
 

--- a/src/main/java/kr/hhplus/be/server/infrastructure/redis/config/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/redis/config/RedisConfig.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -30,7 +30,9 @@ public class RedisConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        // 기본 캐시 설정 - JSON Serializer 사용
+        JdkSerializationRedisSerializer serializer = new JdkSerializationRedisSerializer();
+
+        // 기본 캐시 설정
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .disableCachingNullValues()
                 .serializeKeysWith(
@@ -39,21 +41,12 @@ public class RedisConfig {
                         )
                 )
                 .serializeValuesWith(
-                        RedisSerializationContext.SerializationPair.fromSerializer(
-                                new GenericJackson2JsonRedisSerializer()  // JSON으로 변경
-                        )
+                        RedisSerializationContext.SerializationPair.fromSerializer(serializer)
                 );
 
-        // 콘서트 목록 캐시 설정: 1일 TTL
         RedisCacheConfiguration concertsConfig = defaultConfig.entryTtl(Duration.ofDays(1));
-
-        // 콘서트 상세 캐시 설정: 1일 TTL
         RedisCacheConfiguration concertDetailConfig = defaultConfig.entryTtl(Duration.ofDays(1));
-
-        // 스케줄 캐시 설정: 1분 TTL
         RedisCacheConfiguration scheduleConfig = defaultConfig.entryTtl(Duration.ofMinutes(1));
-
-        // 랭킹 캐시 설정: 10초 TTL (실시간성 유지)
         RedisCacheConfiguration rankingConfig = defaultConfig.entryTtl(Duration.ofSeconds(10));
 
         return RedisCacheManager.builder(connectionFactory)

--- a/src/main/java/kr/hhplus/be/server/infrastructure/redis/config/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/redis/config/RedisConfig.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -30,7 +30,7 @@ public class RedisConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        // 기본 캐시 설정
+        // 기본 캐시 설정 - JSON Serializer 사용
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .disableCachingNullValues()
                 .serializeKeysWith(
@@ -40,7 +40,7 @@ public class RedisConfig {
                 )
                 .serializeValuesWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(
-                                new JdkSerializationRedisSerializer()
+                                new GenericJackson2JsonRedisSerializer()  // JSON으로 변경
                         )
                 );
 
@@ -53,11 +53,15 @@ public class RedisConfig {
         // 스케줄 캐시 설정: 1분 TTL
         RedisCacheConfiguration scheduleConfig = defaultConfig.entryTtl(Duration.ofMinutes(1));
 
+        // 랭킹 캐시 설정: 10초 TTL (실시간성 유지)
+        RedisCacheConfiguration rankingConfig = defaultConfig.entryTtl(Duration.ofSeconds(10));
+
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaultConfig.entryTtl(Duration.ofMinutes(10)))
                 .withCacheConfiguration("concerts", concertsConfig)
                 .withCacheConfiguration("concertDetail", concertDetailConfig)
                 .withCacheConfiguration("schedule", scheduleConfig)
+                .withCacheConfiguration("concertRankings", rankingConfig)
                 .build();
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/redis/queue/RedisQueueAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/redis/queue/RedisQueueAdapter.java
@@ -1,0 +1,228 @@
+package kr.hhplus.be.server.infrastructure.redis.queue;
+
+import kr.hhplus.be.server.application.port.out.QueuePort;
+import kr.hhplus.be.server.domain.queue.model.QueueToken;
+import kr.hhplus.be.server.infrastructure.redis.lock.RedisDistributedLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@Primary
+@RequiredArgsConstructor
+public class RedisQueueAdapter implements QueuePort {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisDistributedLock distributedLock;
+
+    private static final String WAITING_QUEUE = "queue:waiting";
+    private static final String ACTIVE_SET = "queue:active";
+    private static final String TOKEN_INFO = "queue:token:";
+    private static final String USER_TOKEN_MAP = "queue:user:";
+    private static final String LOCK_ACTIVATE = "lock:queue:activate";
+
+    private static final int MAX_ACTIVE_USERS = 100;
+    private static final int TOKEN_TTL_MINUTES = 10;
+
+    @Override
+    public QueueToken issue(String userId) {
+        // 기존 토큰 확인
+        String existingToken = redisTemplate.opsForValue().get(USER_TOKEN_MAP + userId);
+        if (existingToken != null && isValidToken(existingToken)) {
+            return new QueueToken(existingToken);
+        }
+
+        // 새 토큰 생성
+        String token = UUID.randomUUID().toString();
+        long timestamp = Instant.now().toEpochMilli();
+
+        // 토큰 정보 저장
+        saveTokenInfo(token, userId, timestamp);
+        redisTemplate.opsForValue().set(USER_TOKEN_MAP + userId, token, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+
+        // 원자적 카운터로 동시성 제어
+        Long currentCount = redisTemplate.opsForValue().increment("queue:active:counter");
+
+        if (currentCount != null && currentCount <= MAX_ACTIVE_USERS) {
+            // 100명 이내면 활성화
+            activateToken(token);
+            log.info("토큰 발급 완료: userId={}, activated=true", userId);
+        } else {
+            // 초과하면 카운터 롤백하고 대기열 추가
+            redisTemplate.opsForValue().decrement("queue:active:counter");
+            redisTemplate.opsForZSet().add(WAITING_QUEUE, token, (double) timestamp);
+            redisTemplate.opsForHash().put(TOKEN_INFO + token, "status", "WAITING");
+            log.info("토큰 발급 완료: userId={}, activated=false", userId);
+        }
+
+        return new QueueToken(token);
+    }
+
+    private boolean tryActivateWithLock(String token, long timestamp) {
+        log.debug("활성화 시도: token={}", token);
+        try {
+            Boolean result = distributedLock.executeWithLock(
+                    LOCK_ACTIVATE, 10, 50, 100,  // TTL 10초, retry 50번, 100ms 대기 = 최대 5초
+                    () -> {
+                        Long activeCount = redisTemplate.opsForSet().size(ACTIVE_SET);
+                        log.debug("현재 활성 사용자 수: {}", activeCount);
+
+                        if (activeCount != null && activeCount < MAX_ACTIVE_USERS) {
+                            activateToken(token);
+                            log.debug("즉시 활성화: token={}", token);
+                            return true;
+                        } else {
+                            redisTemplate.opsForZSet().add(WAITING_QUEUE, token, (double) timestamp);
+                            redisTemplate.opsForHash().put(TOKEN_INFO + token, "status", "WAITING");
+                            log.debug("대기열 추가: token={}, activeCount={}", token, activeCount);
+                            return false;
+                        }
+                    }
+            );
+            log.debug("분산락 실행 결과: token={}, result={}", token, result);
+            return result != null && result;
+        } catch (Exception e) {
+            log.error("분산락 획득 실패, 대기열에 추가: token={}", token, e);
+            // 락 획득 실패 시 안전하게 대기열에 추가
+            redisTemplate.opsForZSet().add(WAITING_QUEUE, token, (double) timestamp);
+            redisTemplate.opsForHash().put(TOKEN_INFO + token, "status", "WAITING");
+            return false;
+        }
+    }
+
+    private void activateToken(String token) {
+        redisTemplate.opsForZSet().remove(WAITING_QUEUE, token);
+        redisTemplate.opsForSet().add(ACTIVE_SET, token);
+        redisTemplate.opsForHash().put(TOKEN_INFO + token, "status", "ACTIVE");
+        redisTemplate.expire(TOKEN_INFO + token, TOKEN_TTL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    private void saveTokenInfo(String token, String userId, long timestamp) {
+        Map<String, String> tokenInfo = new HashMap<>();
+        tokenInfo.put("userId", userId);
+        tokenInfo.put("issuedAt", String.valueOf(timestamp));
+        tokenInfo.put("status", "PENDING");
+        redisTemplate.opsForHash().putAll(TOKEN_INFO + token, tokenInfo);
+    }
+
+    @Override
+    public boolean isActive(String token) {
+        Boolean isMember = redisTemplate.opsForSet().isMember(ACTIVE_SET, token);
+        return Boolean.TRUE.equals(isMember);
+    }
+
+    @Override
+    public String userIdOf(String token) {
+        Object userId = redisTemplate.opsForHash().get(TOKEN_INFO + token, "userId");
+        return userId != null ? userId.toString() : null;
+    }
+
+    @Override
+    public void expire(String token) {
+        String userId = userIdOf(token);
+
+        // 활성 토큰이었는지 확인 (status로 판단)
+        Object status = redisTemplate.opsForHash().get(TOKEN_INFO + token, "status");
+        boolean wasActive = "ACTIVE".equals(status);
+
+        // 활성 토큰이었다면 카운터와 SET 모두 정리
+        if (wasActive) {
+            redisTemplate.opsForValue().decrement("queue:active:counter");
+            redisTemplate.opsForSet().remove(ACTIVE_SET, token);
+        }
+
+        // 대기열과 토큰 정보 정리
+        redisTemplate.opsForZSet().remove(WAITING_QUEUE, token);
+        redisTemplate.delete(TOKEN_INFO + token);
+        if (userId != null) {
+            redisTemplate.delete(USER_TOKEN_MAP + userId);
+        }
+    }
+
+    @Override
+    public Long getWaitingPosition(String token) {
+        Long rank = redisTemplate.opsForZSet().rank(WAITING_QUEUE, token);
+        return rank != null ? rank + 1 : null;
+    }
+
+    @Override
+    public Long getActiveCount() {
+        String counterStr = redisTemplate.opsForValue().get("queue:active:counter");
+        if (counterStr == null) {
+            return 0L;
+        }
+        try {
+            long counter = Long.parseLong(counterStr);
+            return Math.max(0, counter); // 음수 방지
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    @Override
+    public Long getWaitingCount() {
+        Long count = redisTemplate.opsForZSet().size(WAITING_QUEUE);
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public void activateNextUsers(int count) {
+        if (count <= 0) return;
+
+        try {
+            distributedLock.executeWithLock(
+                    LOCK_ACTIVATE, 10, 3, 200,
+                    () -> {
+                        cleanupExpiredTokens();
+
+                        Long activeCount = getActiveCount();
+                        int availableSlots = MAX_ACTIVE_USERS - activeCount.intValue();
+                        if (availableSlots <= 0) return null;
+
+                        int toActivate = Math.min(count, availableSlots);
+                        Set<String> tokens = redisTemplate.opsForZSet().range(WAITING_QUEUE, 0, toActivate - 1);
+
+                        if (tokens != null && !tokens.isEmpty()) {
+                            tokens.forEach(this::activateToken);
+                            log.info("대기열 활성화: {}명", tokens.size());
+                        }
+                        return null;
+                    }
+            );
+        } catch (Exception e) {
+            log.error("대기열 활성화 실패", e);
+        }
+    }
+
+    private boolean isValidToken(String token) {
+        if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(ACTIVE_SET, token))) {
+            return true;
+        }
+        Double score = redisTemplate.opsForZSet().score(WAITING_QUEUE, token);
+        return score != null;
+    }
+
+    private void cleanupExpiredTokens() {
+        Set<String> activeTokens = redisTemplate.opsForSet().members(ACTIVE_SET);
+        if (activeTokens == null || activeTokens.isEmpty()) return;
+
+        int cleaned = 0;
+        for (String token : activeTokens) {
+            Boolean exists = redisTemplate.hasKey(TOKEN_INFO + token);
+            if (!Boolean.TRUE.equals(exists)) {
+                redisTemplate.opsForSet().remove(ACTIVE_SET, token);
+                cleaned++;
+            }
+        }
+        if (cleaned > 0) {
+            log.info("만료 토큰 정리: {}개", cleaned);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/redis/ranking/RedisRankingAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/redis/ranking/RedisRankingAdapter.java
@@ -1,0 +1,76 @@
+package kr.hhplus.be.server.infrastructure.redis.ranking;
+
+import kr.hhplus.be.server.application.port.out.RankingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRankingAdapter implements RankingPort {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // Redis Key 상수 추가
+    private static final String VELOCITY_RANKING = "ranking:velocity:current";
+    private static final String SOLDOUT_RANKING = "ranking:soldout:fastest";
+    private static final String SCHEDULE_STATS = "stats:schedule:";
+
+    @Override
+    public void saveStats(String scheduleId, Map<String, String> stats) {
+        String key = SCHEDULE_STATS + scheduleId;
+        redisTemplate.opsForHash().putAll(key, stats);
+    }
+
+    @Override
+    public Map<String, String> getStats(String scheduleId) {
+        String key = SCHEDULE_STATS + scheduleId;
+        Map<Object, Object> hashEntries = redisTemplate.opsForHash().entries(key);
+
+        // Object를 String으로 변환
+        Map<String, String> result = new HashMap<>();
+        hashEntries.forEach((k, v) -> result.put(k.toString(), v.toString()));
+        return result;
+    }
+
+    @Override
+    public void updateVelocityRanking(String scheduleId, double score) {
+        String hourKey = "ranking:velocity:" + getCurrentHour();
+        redisTemplate.opsForZSet().add(hourKey, "schedule:" + scheduleId, score);
+    }
+
+    @Override
+    public void updateSoldOutRanking(String scheduleId, long seconds) {
+        redisTemplate.opsForZSet().add(SOLDOUT_RANKING, "schedule:" + scheduleId, (double) seconds);
+    }
+
+    @Override
+    public Set<String> getTopByVelocity(int limit) {
+        // 현재 시간대 키 사용
+        String currentHourKey = "ranking:velocity:" + getCurrentHour();
+        Set<String> result = redisTemplate.opsForZSet().reverseRange(currentHourKey, 0, limit - 1);
+
+        // null 체크 후 반환
+        return result != null ? result : Set.of();
+    }
+
+    @Override
+    public Set<String> getTopBySoldOut(int limit) {
+        Set<String> result = redisTemplate.opsForZSet().range(SOLDOUT_RANKING, 0, limit - 1);
+
+        // null 체크 후 반환
+        return result != null ? result : Set.of();
+    }
+
+    // Helper 메서드 추가
+    private String getCurrentHour() {
+        return LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/web/ranking/RankingController.java
+++ b/src/main/java/kr/hhplus/be/server/web/ranking/RankingController.java
@@ -20,17 +20,12 @@ public class RankingController {
     private final RankingUseCase rankingUseCase;
 
     /**
-     * 현재 빠르게 판매 중인 공연 (판매 속도)
+     * 빠른 판매 랭킹 조회
+     * 판매 속도 기준, 매진 여부 포함
      */
-    @GetMapping("/selling/fast")
-    public ResponseEntity<List<FastSellingDto>> getFastSelling(
+    @GetMapping("/fast-selling")
+    public ResponseEntity<List<ConcertRankingDto>> getFastSelling(
             @RequestParam(defaultValue = "10") int limit) {
         return ResponseEntity.ok(rankingUseCase.getFastSellingRanking(limit));
-    }
-
-    @GetMapping("/soldout/fastest")
-    public ResponseEntity<List<SoldOutRankingDto>> getFastestSoldOut(
-            @RequestParam(defaultValue = "10") int limit) {
-        return ResponseEntity.ok(rankingUseCase.getFastestSoldOutRanking(limit));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/web/ranking/RankingController.java
+++ b/src/main/java/kr/hhplus/be/server/web/ranking/RankingController.java
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.web.ranking;
+
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.service.ConcertService;
+import kr.hhplus.be.server.application.port.in.RankingUseCase.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/rankings")
+@RequiredArgsConstructor
+public class RankingController {
+    private final RankingUseCase rankingUseCase;
+
+    /**
+     * 현재 빠르게 판매 중인 공연 (판매 속도)
+     */
+    @GetMapping("/selling/fast")
+    public ResponseEntity<List<FastSellingDto>> getFastSelling(
+            @RequestParam(defaultValue = "10") int limit) {
+        return ResponseEntity.ok(rankingUseCase.getFastSellingRanking(limit));
+    }
+
+    @GetMapping("/soldout/fastest")
+    public ResponseEntity<List<SoldOutRankingDto>> getFastestSoldOut(
+            @RequestParam(defaultValue = "10") int limit) {
+        return ResponseEntity.ok(rankingUseCase.getFastestSoldOutRanking(limit));
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/ReservationServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/ReservationServiceTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server;
 
 import kr.hhplus.be.server.application.port.in.PaymentUseCase;
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
 import kr.hhplus.be.server.application.port.in.ReservationUseCase.*;
 import kr.hhplus.be.server.application.port.out.*;
 import kr.hhplus.be.server.application.service.ReservationService;
@@ -41,6 +42,7 @@ class ReservationServiceTest {
     @Mock private SeatHoldPort seatHoldPort;
     @Mock private RedisDistributedLock distributedLock;
     @Mock private TransactionTemplate transactionTemplate;
+    @Mock private RankingUseCase rankingUseCase;
 
     private ReservationService reservationService;
 
@@ -59,7 +61,8 @@ class ReservationServiceTest {
                 domainService,
                 seatHoldPort,
                 distributedLock,
-                transactionTemplate
+                transactionTemplate,
+                rankingUseCase
         );
 
         // 분산락과 트랜잭션 Mock 동작 설정

--- a/src/test/java/kr/hhplus/be/server/cache/CachePerformanceTest.java
+++ b/src/test/java/kr/hhplus/be/server/cache/CachePerformanceTest.java
@@ -117,14 +117,14 @@ class CachePerformanceTest {
         int measureCount = 100;    // 티켓 오픈 시 폭발적인 트래픽
 
         // 1단계: 워밍업 (JVM 최적화 + 초기 사용자 시뮬레이션)
-        log.info("🔥 워밍업 시작 ({}회)...", warmupCount);
+        log.info("워밍업 시작 ({}회)...", warmupCount);
         for (int i = 0; i < warmupCount; i++) {
             concertService.getAllConcerts();
         }
 
         // 2단계: 캐시 클리어 후 캐시 미스 측정 (DB 조회)
         cacheManager.getCache("concerts").clear();
-        log.info("📊 캐시 미스 측정 ({}회 반복)...", measureCount);
+        log.info("캐시 미스 측정 ({}회 반복)...", measureCount);
 
         long totalTimeMiss = 0;
         for (int i = 0; i < measureCount; i++) {
@@ -136,7 +136,7 @@ class CachePerformanceTest {
         long avgTimeMissNano = totalTimeMiss / measureCount;
 
         // 3단계: 캐시 히트 측정 (캐시에서 조회)
-        log.info("⚡ 캐시 히트 측정 ({}회 반복)...", measureCount);
+        log.info("캐시 히트 측정 ({}회 반복)...", measureCount);
         concertService.getAllConcerts(); // 캐시 채우기
 
         long totalTimeHit = 0;
@@ -152,7 +152,7 @@ class CachePerformanceTest {
         long avgTimeHitMs = avgTimeHitNano / 1_000_000;
 
         // Then: 결과 검증
-        log.info("📈 콘서트 목록 캐시 성능 ({}회 평균):", measureCount);
+        log.info("콘서트 목록 캐시 성능 ({}회 평균):", measureCount);
         log.info("  - 캐시 미스 (DB 조회): {}ms ({}ns)", avgTimeMissMs, avgTimeMissNano);
         log.info("  - 캐시 히트 (메모리):  {}ms ({}ns)", avgTimeHitMs, avgTimeHitNano);
         if (avgTimeMissNano > 0) {

--- a/src/test/java/kr/hhplus/be/server/infrastructure/redis/lock/RedisDistributedLockTest.java
+++ b/src/test/java/kr/hhplus/be/server/infrastructure/redis/lock/RedisDistributedLockTest.java
@@ -1,6 +1,5 @@
 package kr.hhplus.be.server.infrastructure.redis.lock;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,22 +8,25 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.*;
 
+/**
+ * RedisDistributedLock 단위 테스트
+ */
 @SpringBootTest
+@DisplayName("RedisDistributedLockTest")
 class RedisDistributedLockTest {
+
+    private static final String TEST_LOCK_KEY = "test:lock:";
 
     @Autowired
     private RedisDistributedLock distributedLock;
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
-
-    private static final String TEST_LOCK_KEY = "test:lock:";
 
     @BeforeEach
     void setUp() {
@@ -33,32 +35,28 @@ class RedisDistributedLockTest {
                 .forEach(key -> redisTemplate.delete(key));
     }
 
-    @AfterEach
-    void tearDown() {
-        // 테스트 후 Redis 클린업
-        redisTemplate.keys(TEST_LOCK_KEY + "*")
-                .forEach(key -> redisTemplate.delete(key));
-    }
-
     @Test
     @DisplayName("락 획득 및 해제 - 기본 동작")
-    void basicLockAndUnlock() {
+    void basicLockAndUnlock() throws InterruptedException {
         // given
         String lockKey = TEST_LOCK_KEY + "basic";
 
-        // when
+        // when: 짧은 TTL로 작업 실행
         String result = distributedLock.executeWithLock(
                 lockKey,
-                5L,      // 5초 TTL
+                1L,      // 1초 TTL (테스트용)
                 1,       // 재시도 없음
                 0L,
                 () -> "success"
         );
 
-        // then
+        // then: 작업 성공
         assertThat(result).isEqualTo("success");
 
-        // 락이 해제되었는지 확인
+        // TTL로 자동 만료되기 때문에, 짧은 시간 이후 락이 없어야 함
+        // Note: 예전에는 명시적 unlock 호출이 있었지만,
+        // race condition을 피하기 위해 TTL로만 관리하는 방식으로 변경됨
+        Thread.sleep(1500); // TTL(1초) + 여유
         String lockValue = redisTemplate.opsForValue().get(lockKey);
         assertThat(lockValue).isNull();
     }
@@ -75,79 +73,59 @@ class RedisDistributedLockTest {
 
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger failCount = new AtomicInteger(0);
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
         // when: 10개 스레드가 동시에 락 획득 시도
         for (int i = 0; i < threadCount; i++) {
-            final int threadNum = i;
-            executor.submit(() -> {
+            new Thread(() -> {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
 
-                    System.out.println("Thread-" + threadNum + " 시작");
-
                     distributedLock.executeWithLock(
                             lockKey,
-                            3L,
-                            1,      // ⭐ 재시도 없음 (바로 실패)
+                            5L,
+                            1,   // 재시도 없음 (충돌 확인용)
                             0L,
                             () -> {
-                                System.out.println("Thread-" + threadNum + " 락 획득 성공!");
-                                sleep(1000);
                                 successCount.incrementAndGet();
+                                sleep(100); // 작업 시간
                                 return null;
                             }
                     );
                 } catch (LockAcquisitionException e) {
-                    System.out.println("Thread-" + threadNum + " 락 획득 실패! (LockAcquisitionException)");
                     failCount.incrementAndGet();
-                } catch (InterruptedException e) {
-                    System.out.println("Thread-" + threadNum + " 인터럽트 발생!");  // ⭐ 로그 추가
-                    failCount.incrementAndGet();  // ⭐ 카운트 추가
-                    Thread.currentThread().interrupt();
-                } catch (Exception e) {  // ⭐ 모든 예외 잡기
-                    System.out.println("Thread-" + threadNum + " 예외 발생: " + e.getClass().getName() + " - " + e.getMessage());
-                    e.printStackTrace();
+                } catch (Exception e) {
                     failCount.incrementAndGet();
                 } finally {
                     finishLatch.countDown();
                 }
-            });
+            }).start();
         }
 
         readyLatch.await();
-        System.out.println("모든 스레드 준비 완료");
         startLatch.countDown();
-        System.out.println("시작 신호 발송!");
-        finishLatch.await();
-        System.out.println("모든 스레드 완료");
-        executor.shutdown();
+        finishLatch.await(10, TimeUnit.SECONDS);
 
-        // then
-        System.out.println("=== 최종 결과 ===");
-        System.out.println("Success: " + successCount.get());
-        System.out.println("Fail: " + failCount.get());
-        System.out.println("Total: " + (successCount.get() + failCount.get()));  // ⭐ 합계 확인
-
+        // then: 한 번에 하나씩만 실행되어야 함
+        // retry가 없으므로 1개만 성공
         assertThat(successCount.get()).isEqualTo(1);
         assertThat(failCount.get()).isEqualTo(9);
     }
 
     @Test
-    @DisplayName("Retry 로직 - 재시도 후 성공")
+    @DisplayName("재시도 메커니즘 - 락 획득 성공")
     void retryMechanism() throws InterruptedException {
         // given
         String lockKey = TEST_LOCK_KEY + "retry";
 
-        // 먼저 락 획득
+        // 먼저 락을 잡아둠 (0.5초 TTL)
         distributedLock.executeWithLock(
                 lockKey,
-                1L,  // 1초 TTL
+                1L,  // 0.5초보다 긴 TTL
                 1,
                 0L,
                 () -> {
-                    sleep(500);  // 0.5초 작업
+                    sleep(500);
                     return null;
                 }
         );
@@ -168,15 +146,15 @@ class RedisDistributedLockTest {
 
     @Test
     @DisplayName("예외 발생 시에도 락 해제")
-    void lockReleasedOnException() {
+    void lockReleasedOnException() throws InterruptedException {
         // given
         String lockKey = TEST_LOCK_KEY + "exception";
 
-        // when & then
+        // when & then: 예외 발생
         assertThatThrownBy(() ->
                 distributedLock.executeWithLock(
                         lockKey,
-                        5L,
+                        1L,  // 1초 TTL
                         1,
                         0L,
                         () -> {
@@ -185,7 +163,8 @@ class RedisDistributedLockTest {
                 )
         ).isInstanceOf(RuntimeException.class);
 
-        // 예외가 발생해도 락은 해제되어야 함
+        // 예외가 발생해도 TTL로 락은 자동 만료됨
+        Thread.sleep(1500);
         String lockValue = redisTemplate.opsForValue().get(lockKey);
         assertThat(lockValue).isNull();
     }

--- a/src/test/java/kr/hhplus/be/server/queue/RedisQueueTest.java
+++ b/src/test/java/kr/hhplus/be/server/queue/RedisQueueTest.java
@@ -1,0 +1,412 @@
+package kr.hhplus.be.server.queue;
+
+import kr.hhplus.be.server.application.port.out.QueuePort;
+import kr.hhplus.be.server.domain.queue.model.QueueToken;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Redis 대기열 통합 테스트
+ *
+ * 주요 검증 사항:
+ * 1. 기본 토큰 발급/조회 기능
+ * 2. 100명 제한 동시성 제어
+ * 3. 토큰 만료 및 재활성화
+ * 4. 대기열 순서 관리
+ */
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class RedisQueueTest {
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(
+            DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port",
+                () -> redis.getMappedPort(6379).toString());
+    }
+
+    @Autowired
+    private QueuePort queuePort;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // Redis 완전 초기화
+        redisTemplate.getConnectionFactory().getConnection().flushDb();
+
+        // Redis 처리 완료 대기
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Nested
+    @DisplayName("기본 토큰 발급 테스트")
+    class BasicTokenIssueTest {
+
+        @Test
+        @Order(1)
+        @DisplayName("토큰을 발급하면 null이 아닌 값을 반환한다")
+        void issueToken() {
+            // given
+            String userId = "user-001";
+
+            // when
+            QueueToken token = queuePort.issue(userId);
+
+            // then
+            assertThat(token).isNotNull();
+            assertThat(token.value()).isNotBlank();
+            log.info("토큰 발급 성공: {}", token.value());
+        }
+
+        @Test
+        @Order(2)
+        @DisplayName("같은 사용자가 재발급 요청하면 동일한 토큰을 반환한다")
+        void returnSameTokenForSameUser() {
+            // given
+            String userId = "user-001";
+            QueueToken firstToken = queuePort.issue(userId);
+
+            // when
+            QueueToken secondToken = queuePort.issue(userId);
+
+            // then
+            assertThat(firstToken.value()).isEqualTo(secondToken.value());
+            log.info("재발급 토큰 일치 확인: {}", firstToken.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("활성화 규칙 테스트")
+    class ActivationRuleTest {
+
+        @Test
+        @DisplayName("활성 사용자가 100명 미만이면 즉시 활성화된다")
+        void activateWhenUnder100() {
+            // given
+            String userId = "user-001";
+
+            // when
+            QueueToken token = queuePort.issue(userId);
+
+            // then
+            assertThat(queuePort.isActive(token.value())).isTrue();
+            assertThat(queuePort.getActiveCount()).isEqualTo(1L);
+            assertThat(queuePort.getWaitingCount()).isEqualTo(0L);
+
+            log.info("즉시 활성화 확인 - token: {}, activeCount: {}",
+                    token.value(), queuePort.getActiveCount());
+        }
+
+        @Test
+        @DisplayName("활성 사용자가 100명이면 대기열에 추가된다")
+        void waitingWhenAt100() {
+            // given - 100명 먼저 활성화
+            for (int i = 1; i <= 100; i++) {
+                queuePort.issue("user-" + i);
+            }
+            assertThat(queuePort.getActiveCount()).isEqualTo(100L);
+
+            // when - 101번째 사용자 발급
+            QueueToken token = queuePort.issue("user-101");
+
+            // then
+            assertThat(queuePort.isActive(token.value())).isFalse();
+            assertThat(queuePort.getActiveCount()).isEqualTo(100L);
+            assertThat(queuePort.getWaitingCount()).isEqualTo(1L);
+
+            log.info("대기열 추가 확인 - waiting token: {}, waitingCount: {}",
+                    token.value(), queuePort.getWaitingCount());
+        }
+
+        @Test
+        @DisplayName("대기 순번을 정확하게 조회할 수 있다")
+        void getWaitingPosition() {
+            // given - 100명 활성화
+            for (int i = 1; i <= 100; i++) {
+                queuePort.issue("active-" + i);
+            }
+
+            // when - 대기열에 2명 추가
+            QueueToken token1 = queuePort.issue("waiting-1");
+            QueueToken token2 = queuePort.issue("waiting-2");
+
+            // then
+            Long position1 = queuePort.getWaitingPosition(token1.value());
+            Long position2 = queuePort.getWaitingPosition(token2.value());
+
+            assertThat(position1).isEqualTo(1L);
+            assertThat(position2).isEqualTo(2L);
+
+            log.info("대기 순번 확인 - token1: {}번, token2: {}번", position1, position2);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 만료 및 재활성화 테스트")
+    class TokenExpirationTest {
+
+        @Test
+        @DisplayName("토큰을 만료시키면 활성 상태가 해제된다")
+        void expireToken() {
+            // given
+            QueueToken token = queuePort.issue("user-001");
+            assertThat(queuePort.isActive(token.value())).isTrue();
+            Long beforeCount = queuePort.getActiveCount();
+
+            // when
+            queuePort.expire(token.value());
+
+            // then
+            assertThat(queuePort.isActive(token.value())).isFalse();
+            assertThat(queuePort.getActiveCount()).isEqualTo(beforeCount - 1);
+
+            log.info("토큰 만료 확인 - token: {}, 만료 전: {}, 만료 후: {}",
+                    token.value(), beforeCount, queuePort.getActiveCount());
+        }
+
+        @Test
+        @DisplayName("토큰 만료 후 새 사용자가 활성화될 수 있다")
+        void newUserCanActivateAfterExpire() {
+            // given - 100명 활성화
+            List<QueueToken> activeTokens = new ArrayList<>();
+            for (int i = 1; i <= 100; i++) {
+                activeTokens.add(queuePort.issue("user-" + i));
+            }
+
+            // 101번째는 대기
+            QueueToken waitingToken = queuePort.issue("waiting-user");
+            assertThat(queuePort.isActive(waitingToken.value())).isFalse();
+
+            // when - 1번 사용자 만료
+            queuePort.expire(activeTokens.get(0).value());
+
+            // then - 새 사용자가 활성화 가능
+            QueueToken newToken = queuePort.issue("new-user");
+            assertThat(queuePort.isActive(newToken.value())).isTrue();
+            assertThat(queuePort.getActiveCount()).isEqualTo(100L);
+
+            log.info("만료 후 재활성화 확인 - 새 토큰: {}, activeCount: {}",
+                    newToken.value(), queuePort.getActiveCount());
+        }
+    }
+
+    @Nested
+    @DisplayName("동시성 제어 테스트")
+    class ConcurrencyTest {
+
+        @Test
+        @DisplayName("여러 명이 동시에 토큰을 발급받아도 정확히 100명만 활성화된다")
+        void concurrentIssue() throws InterruptedException {
+            // given
+            int totalUsers = 150;
+            int threadPoolSize = 50;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch endLatch = new CountDownLatch(totalUsers);
+            ExecutorService executor = Executors.newFixedThreadPool(threadPoolSize);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            // when - 150명 동시 요청
+            long startTime = System.currentTimeMillis();
+
+            for (int i = 1; i <= totalUsers; i++) {
+                String userId = "user-" + i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        QueueToken token = queuePort.issue(userId);
+
+                        if (queuePort.isActive(token.value())) {
+                            successCount.incrementAndGet();
+                        } else {
+                            failCount.incrementAndGet();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Exception e) {
+                        log.error("토큰 발급 실패: userId={}", userId, e);
+                        failCount.incrementAndGet();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown(); // 동시 시작
+            boolean completed = endLatch.await(15, TimeUnit.SECONDS);
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+
+            long endTime = System.currentTimeMillis();
+
+            // Redis 처리 완료 대기
+            Thread.sleep(500);
+
+            // then
+            assertThat(completed).isTrue();
+
+            Long activeCount = queuePort.getActiveCount();
+            Long waitingCount = queuePort.getWaitingCount();
+
+            log.info("=== 동시성 테스트 결과 ===");
+            log.info("총 요청: {}명", totalUsers);
+            log.info("스레드 풀: {}개", threadPoolSize);
+            log.info("소요 시간: {}ms", endTime - startTime);
+            log.info("활성화 성공: {}명 (스레드 카운트: {})", activeCount, successCount.get());
+            log.info("대기열 추가: {}명 (스레드 카운트: {})", waitingCount, failCount.get());
+            log.info("========================");
+
+            assertThat(activeCount).isEqualTo(100L);
+            assertThat(waitingCount).isEqualTo(50L);
+            assertThat(activeCount + waitingCount).isEqualTo((long) totalUsers);
+        }
+
+        @Test
+        @DisplayName("동시 만료와 신규 발급이 있어도 100명 제한이 유지된다")
+        void concurrentExpireAndIssue() throws InterruptedException {
+            // given - 먼저 100명 활성화
+            List<QueueToken> tokens = new ArrayList<>();
+            for (int i = 1; i <= 100; i++) {
+                tokens.add(queuePort.issue("initial-" + i));
+            }
+
+            int expireCount = 30;
+            int newIssueCount = 50;
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch endLatch = new CountDownLatch(expireCount + newIssueCount);
+            ExecutorService executor = Executors.newFixedThreadPool(20);
+
+            // when - 30명 만료 + 50명 신규 발급 동시 진행
+            // 만료 작업
+            for (int i = 0; i < expireCount; i++) {
+                int index = i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        queuePort.expire(tokens.get(index).value());
+                    } catch (Exception e) {
+                        log.error("만료 실패", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+
+            // 신규 발급 작업
+            for (int i = 1; i <= newIssueCount; i++) {
+                String userId = "new-user-" + i;
+                executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        queuePort.issue(userId);
+                    } catch (Exception e) {
+                        log.error("발급 실패", e);
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            boolean completed = endLatch.await(10, TimeUnit.SECONDS);
+            executor.shutdown();
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+
+            Thread.sleep(500);
+
+            // then
+            assertThat(completed).isTrue();
+
+            Long activeCount = queuePort.getActiveCount();
+            Long waitingCount = queuePort.getWaitingCount();
+
+            log.info("=== 혼합 동시성 테스트 결과 ===");
+            log.info("초기 활성: 100명");
+            log.info("만료: {}명", expireCount);
+            log.info("신규 발급: {}명", newIssueCount);
+            log.info("최종 활성: {}명", activeCount);
+            log.info("최종 대기: {}명", waitingCount);
+            log.info("============================");
+
+            // 100명 - 30명(만료) + 30명(신규 활성) = 100명 유지
+            assertThat(activeCount).isLessThanOrEqualTo(100L);
+            assertThat(activeCount).isGreaterThan(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지 케이스 테스트")
+    class EdgeCaseTest {
+
+        @Test
+        @DisplayName("존재하지 않는 토큰 조회 시 적절히 처리된다")
+        void handleNonExistentToken() {
+            // given
+            String nonExistentToken = "non-existent-token";
+
+            // when & then
+            assertThat(queuePort.isActive(nonExistentToken)).isFalse();
+            assertThat(queuePort.getWaitingPosition(nonExistentToken)).isNull();
+            assertThat(queuePort.userIdOf(nonExistentToken)).isNull();
+
+            // 만료해도 예외 발생하지 않음
+            assertThatCode(() -> queuePort.expire(nonExistentToken))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("동일한 토큰을 여러 번 만료해도 카운터가 음수가 되지 않는다")
+        void expireTokenMultipleTimes() {
+            // given
+            QueueToken token = queuePort.issue("user-001");
+            assertThat(queuePort.getActiveCount()).isEqualTo(1L);
+
+            // when - 같은 토큰 3번 만료
+            queuePort.expire(token.value());
+            queuePort.expire(token.value());
+            queuePort.expire(token.value());
+
+            // then
+            Long activeCount = queuePort.getActiveCount();
+            assertThat(activeCount).isGreaterThanOrEqualTo(0L);
+
+            log.info("중복 만료 후 activeCount: {}", activeCount);
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/ranking/ConcertRankingServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/ranking/ConcertRankingServiceTest.java
@@ -1,0 +1,233 @@
+package kr.hhplus.be.server.ranking;
+
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.port.in.RankingUseCase.ConcertRankingDto;
+import kr.hhplus.be.server.concurrency.config.TestTaskExecutorConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * 콘서트 랭킹 서비스 핵심 테스트
+ *
+ * 과제 요구사항: 빠른 매진 랭킹 (통합)
+ */
+@Slf4j
+@SpringBootTest
+@Import(TestTaskExecutorConfig.class)
+@DisplayName("콘서트 랭킹 서비스 테스트")
+class ConcertRankingServiceTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private RankingUseCase rankingService;
+
+    @Autowired
+    @Qualifier("concurrencyTestExecutor")
+    private TaskExecutor taskExecutor;
+
+    @BeforeEach
+    void setUp() {
+        cleanupRedis();
+    }
+
+    private void cleanupRedis() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("100명 동시 예약 → 정확히 100개 집계 (동시성 검증)")
+    void concurrentReservationsShouldBeCountedAccurately() throws InterruptedException {
+        // Given
+        Long scheduleId = 1L;
+        int threadCount = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger errorCount = new AtomicInteger(0);
+
+        // When - 100명 동시 예약
+        for (int i = 0; i < threadCount; i++) {
+            taskExecutor.execute(() -> {
+                try {
+                    startLatch.await();
+                    rankingService.trackReservation(scheduleId, 1);
+                } catch (Exception e) {
+                    errorCount.incrementAndGet();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertThat(endLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        // Then - 정확히 100개 집계
+        List<ConcertRankingDto> rankings = rankingService.getFastSellingRanking(10);
+
+        assertThat(errorCount.get()).isEqualTo(0);
+        assertThat(rankings).isNotEmpty();
+        assertThat(rankings.get(0).soldCount()).isEqualTo(100);
+        assertThat(rankings.get(0).isSoldOut()).isTrue();
+
+        log.info("동시성 테스트 통과: {}석 정확히 집계, 매진 상태: {}",
+                rankings.get(0).soldCount(), rankings.get(0).isSoldOut());
+    }
+
+    @Test
+    @DisplayName("99석 vs 100석 - 매진 상태 정확히 반영")
+    void shouldReflectSoldOutStatusAccurately() throws InterruptedException {
+        // Given
+        Long scheduleId = 2L;
+
+        // When - 99석 판매
+        for (int i = 0; i < 99; i++) {
+            rankingService.trackReservation(scheduleId, 1);
+        }
+
+        Thread.sleep(100);
+
+        // Then - 랭킹에 존재, 매진 아님
+        List<ConcertRankingDto> rankings = rankingService.getFastSellingRanking(10);
+        ConcertRankingDto concert = rankings.stream()
+                .filter(dto -> dto.scheduleId().equals(scheduleId))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(concert.soldCount()).isEqualTo(99);
+        assertThat(concert.isSoldOut()).isFalse();
+        assertThat(concert.soldOutSeconds()).isNull();
+        log.info("99석: soldCount={}, isSoldOut={}", concert.soldCount(), concert.isSoldOut());
+
+        // When - 1석 추가 판매 (매진)
+        rankingService.trackReservation(scheduleId, 1);
+
+        // Then - 매진 상태로 변경
+        rankings = rankingService.getFastSellingRanking(10);
+        concert = rankings.stream()
+                .filter(dto -> dto.scheduleId().equals(scheduleId))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(concert.soldCount()).isEqualTo(100);
+        assertThat(concert.isSoldOut()).isTrue();
+        assertThat(concert.soldOutSeconds()).isNotNull();
+        log.info("100석: soldCount={}, isSoldOut={}, soldOutSeconds={}초",
+                concert.soldCount(), concert.isSoldOut(), concert.soldOutSeconds());
+    }
+
+    @Test
+    @DisplayName("매진 후 추가 예약 시도 → 집계 차단")
+    void soldOutConcertShouldBlockAdditionalReservations() {
+        // Given - 100석 매진
+        Long scheduleId = 3L;
+        for (int i = 0; i < 100; i++) {
+            rankingService.trackReservation(scheduleId, 1);
+        }
+
+        // When - 매진 후 50회 추가 시도
+        for (int i = 0; i < 50; i++) {
+            rankingService.trackReservation(scheduleId, 1);
+        }
+
+        // Then - 100석에서 멈춤
+        List<ConcertRankingDto> rankings = rankingService.getFastSellingRanking(10);
+        ConcertRankingDto concert = rankings.stream()
+                .filter(dto -> dto.scheduleId().equals(scheduleId))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(concert.soldCount()).isEqualTo(100);
+        log.info("매진 캐싱: 100석에서 멈춤, 추가 집계 차단");
+    }
+
+    @Test
+    @DisplayName("여러 공연 동시 판매 → 판매 속도 순 랭킹")
+    void multipleConcertsShouldBeRankedByVelocity() throws InterruptedException {
+        // Given - 3개 공연
+        Long schedule1 = 101L; // 50석
+        Long schedule2 = 102L; // 30석
+        Long schedule3 = 103L; // 10석
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(90);
+
+        // When - 동시 판매
+        scheduleSales(schedule1, 50, startLatch, endLatch);
+        scheduleSales(schedule2, 30, startLatch, endLatch);
+        scheduleSales(schedule3, 10, startLatch, endLatch);
+
+        startLatch.countDown();
+        assertThat(endLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        // Then - 판매량 순 랭킹
+        List<ConcertRankingDto> rankings = rankingService.getFastSellingRanking(10);
+
+        assertThat(rankings).hasSizeGreaterThanOrEqualTo(3);
+        assertThat(rankings.get(0).scheduleId()).isEqualTo(schedule1);
+        assertThat(rankings.get(0).soldCount()).isEqualTo(50);
+        assertThat(rankings.get(1).scheduleId()).isEqualTo(schedule2);
+        assertThat(rankings.get(1).soldCount()).isEqualTo(30);
+        assertThat(rankings.get(2).scheduleId()).isEqualTo(schedule3);
+        assertThat(rankings.get(2).soldCount()).isEqualTo(10);
+
+        log.info("랭킹 정확도: 50석 > 30석 > 10석 순서 정확");
+    }
+
+    private void scheduleSales(Long scheduleId, int count,
+                               CountDownLatch startLatch,
+                               CountDownLatch endLatch) {
+        for (int i = 0; i < count; i++) {
+            taskExecutor.execute(() -> {
+                try {
+                    startLatch.await();
+                    rankingService.trackReservation(scheduleId, 1);
+                } catch (Exception e) {
+                    log.error("예약 실패", e);
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("매진 캐시 성능 - 100회 호출 1초 이내")
+    void soldOutCachePerformance() {
+        // Given - 매진 상태
+        Long scheduleId = 4L;
+        for (int i = 0; i < 100; i++) {
+            rankingService.trackReservation(scheduleId, 1);
+        }
+
+        // When - 100회 호출
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < 100; i++) {
+            rankingService.trackReservation(scheduleId, 1);
+        }
+        long duration = System.currentTimeMillis() - startTime;
+
+        // Then - 1초 이내
+        assertThat(duration).isLessThan(1000L);
+
+        log.info("캐시 성능: 100회 호출 {}ms (1초 이내)", duration);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/ranking/ConcurrencyStressTest.java
+++ b/src/test/java/kr/hhplus/be/server/ranking/ConcurrencyStressTest.java
@@ -1,0 +1,426 @@
+package kr.hhplus.be.server.ranking;
+
+import kr.hhplus.be.server.application.port.in.ReservationUseCase;
+import kr.hhplus.be.server.application.port.in.ReservationUseCase.*;
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.concurrency.config.TestTaskExecutorConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * 극한 동시성 스트레스 테스트
+ *
+ * 실제 프로덕션 환경의 부하 테스트
+ * - 10,000+ 동시 요청
+ * - TPS, Throughput 측정
+ * - 응답 시간 분포
+ * - 데드락, 타임아웃 검증
+ * - 시스템 한계 파악
+ */
+@Slf4j
+@SpringBootTest
+@Import(TestTaskExecutorConfig.class)
+@ActiveProfiles("test")
+@DisplayName("극한 동시성 스트레스")
+class ConcurrencyStressTest {
+
+    @Autowired
+    private ReservationUseCase reservationUseCase;
+
+    @Autowired
+    private RankingUseCase rankingUseCase;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    @Qualifier("concurrencyTestExecutor")
+    private TaskExecutor taskExecutor;
+
+    private ExecutorService stressTestExecutor;
+
+    @BeforeEach
+    void setUp() {
+        // 스트레스 테스트용 대용량 스레드 풀
+        stressTestExecutor = Executors.newFixedThreadPool(200);
+
+        // Redis 초기화
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("10,000명 동시 예약 추적 - 데이터 정합성")
+    void 만명_동시_예약_추적_정합성_검증() throws InterruptedException {
+        // Given
+        Long scheduleId = 1L;
+        int totalRequests = 10_000;
+        int availableSeats = 100;
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(totalRequests);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        List<Long> responseTimes = new CopyOnWriteArrayList<>();
+
+        log.info("=== 10,000명 동시 예약 추적 시작 ===");
+        Instant startTime = Instant.now();
+
+        // When - 10,000명이 동시에 예약 추적
+        for (int i = 0; i < totalRequests; i++) {
+            stressTestExecutor.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    long requestStart = System.currentTimeMillis();
+
+                    try {
+                        // 예약 추적
+                        rankingUseCase.trackReservation(scheduleId, 1);
+
+                        long responseTime = System.currentTimeMillis() - requestStart;
+                        responseTimes.add(responseTime);
+                        successCount.incrementAndGet();
+
+                    } catch (Exception e) {
+                        failureCount.incrementAndGet();
+                    }
+
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        // 동시 시작
+        Thread.sleep(100);
+        startLatch.countDown();
+
+        // 완료 대기 (최대 60초)
+        boolean completed = completionLatch.await(60, TimeUnit.SECONDS);
+        Duration totalDuration = Duration.between(startTime, Instant.now());
+
+        // Then - 상세 분석
+        log.info("");
+        log.info("=== 스트레스 테스트 결과 ===");
+        log.info("총 소요 시간: {}초", totalDuration.getSeconds());
+        log.info("처리량:");
+        log.info("   - 총 요청: {}", totalRequests);
+        log.info("   - 성공: {} ({}%)", successCount.get(),
+                successCount.get() * 100.0 / totalRequests);
+        log.info("   - 실패: {} ({}%)", failureCount.get(),
+                failureCount.get() * 100.0 / totalRequests);
+
+        log.info("");
+        log.info("성능 메트릭:");
+        log.info("   - TPS: {} req/s",
+                totalRequests / Math.max(1, totalDuration.getSeconds()));
+        log.info("   - 처리 완료: {}", completed ? "예" : "아니오 (타임아웃)");
+
+        if (!responseTimes.isEmpty()) {
+            Collections.sort(responseTimes);
+            long p50 = responseTimes.get(responseTimes.size() / 2);
+            long p95 = responseTimes.get((int)(responseTimes.size() * 0.95));
+            long p99 = responseTimes.get((int)(responseTimes.size() * 0.99));
+            long p999 = responseTimes.get((int)(responseTimes.size() * 0.999));
+            long max = responseTimes.get(responseTimes.size() - 1);
+
+            log.info("");
+            log.info("응답 시간 분포:");
+            log.info("   - P50:  {}ms", p50);
+            log.info("   - P95:  {}ms", p95);
+            log.info("   - P99:  {}ms", p99);
+            log.info("   - P999: {}ms", p999);
+            log.info("   - Max:  {}ms", max);
+
+            log.info("");
+            log.info("SLA 검증:");
+            log.info("   - P95 < 3s: {} ({}ms)", p95 < 3000 ? "✅" : "❌", p95);
+            log.info("   - P99 < 5s: {} ({}ms)", p99 < 5000 ? "✅" : "❌", p99);
+        }
+
+        // 실무 검증
+        assertThat(completed).isTrue();
+        assertThat(successCount.get())
+                .as("대부분의 요청은 성공해야 함")
+                .isGreaterThan((int)(totalRequests * 0.9));   // 90% 이상 성공
+
+        // 응답시간 SLA
+        if (!responseTimes.isEmpty()) {
+            long p95 = responseTimes.get((int)(responseTimes.size() * 0.95));
+            assertThat(p95)
+                    .as("P95 응답시간은 3초 이내 (실무 SLA)")
+                    .isLessThan(3000L);
+        }
+    }
+
+
+    @Test
+    @DisplayName("점진적 부하 증가 - 시스템 한계 파악")
+    void 점진적_부하_증가_시스템_한계_파악() throws InterruptedException {
+        // Given - 부하를 점진적으로 증가
+        Long scheduleId = 2L;
+        int[] loadLevels = {100, 500, 1000, 2000, 5000};  // 점진적 증가
+
+        Map<Integer, LoadTestResult> results = new LinkedHashMap<>();
+
+        log.info("=== 점진적 부하 증가 테스트 시작 ===");
+
+        // When - 각 부하 레벨 테스트
+        for (int loadLevel : loadLevels) {
+            log.info("");
+            log.info("부하 레벨: {} req/s", loadLevel);
+
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch completionLatch = new CountDownLatch(loadLevel);
+
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failureCount = new AtomicInteger(0);
+            List<Long> responseTimes = new CopyOnWriteArrayList<>();
+
+            Instant startTime = Instant.now();
+
+            for (int i = 0; i < loadLevel; i++) {
+                final int requestId = i;
+
+                stressTestExecutor.submit(() -> {
+                    try {
+                        startLatch.await();
+
+                        long requestStart = System.currentTimeMillis();
+
+                        try {
+                            rankingUseCase.trackReservation(scheduleId, 1);
+
+                            long responseTime = System.currentTimeMillis() - requestStart;
+                            responseTimes.add(responseTime);
+                            successCount.incrementAndGet();
+
+                        } catch (Exception e) {
+                            failureCount.incrementAndGet();
+                        }
+
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        completionLatch.countDown();
+                    }
+                });
+            }
+
+            startLatch.countDown();
+            boolean completed = completionLatch.await(30, TimeUnit.SECONDS);
+            Duration duration = Duration.between(startTime, Instant.now());
+
+            // 결과 저장
+            LoadTestResult result = new LoadTestResult(
+                    loadLevel,
+                    successCount.get(),
+                    failureCount.get(),
+                    duration.toMillis(),
+                    responseTimes
+            );
+            results.put(loadLevel, result);
+
+            log.info("   - 성공: {} / {}", successCount.get(), loadLevel);
+            log.info("   - 실패: {}", failureCount.get());
+            log.info("   - 소요 시간: {}ms", duration.toMillis());
+
+            if (!responseTimes.isEmpty()) {
+                Collections.sort(responseTimes);
+                long p95 = responseTimes.get((int)(responseTimes.size() * 0.95));
+                log.info("   - P95 응답: {}ms", p95);
+            }
+
+            // 다음 테스트 전 잠시 대기
+            Thread.sleep(1000);
+        }
+
+        // Then - 결과 분석
+        log.info("");
+        log.info("=== 부하 테스트 종합 분석 ===");
+        log.info(String.format("%-10s | %-10s | %-10s | %-12s | %-10s",
+                "부하", "성공률", "TPS", "P95 응답", "판정"));
+        log.info("-".repeat(65));
+
+        for (Map.Entry<Integer, LoadTestResult> entry : results.entrySet()) {
+            LoadTestResult result = entry.getValue();
+            double successRate = result.successCount * 100.0 / result.totalRequests;
+            long tps = result.successCount * 1000 / Math.max(1, result.durationMs);
+
+            long p95 = 0;
+            if (!result.responseTimes.isEmpty()) {
+                Collections.sort(result.responseTimes);
+                p95 = result.responseTimes.get((int)(result.responseTimes.size() * 0.95));
+            }
+
+            String status = successRate >= 95 && p95 < 3000 ? "✅ 정상" : "⚠️ 한계";
+
+            log.info(String.format("%-10d | %-9.1f%% | %-10d | %-10dms | %s",
+                    result.totalRequests, successRate, tps, p95, status));
+        }
+    }
+
+    @Test
+    @DisplayName("순간 트래픽 스파이크 - 버스트 처리")
+    void 순간_트래픽_스파이크_버스트_처리() throws InterruptedException {
+        // Given - 평소 100 TPS, 순간 5000 TPS 스파이크
+        Long scheduleId = 3L;
+
+        log.info("=== 트래픽 스파이크 시뮬레이션 ===");
+        log.info("평상시: 100 TPS");
+        log.info("스파이크: 5000 TPS (50배)");
+        log.info("");
+
+        // When - 단계별 부하
+        List<BurstResult> results = new ArrayList<>();
+
+        // 1. 평상시 부하
+        BurstResult normalLoad = executeBurst("평상시", scheduleId, 100, 1000);
+        results.add(normalLoad);
+
+        Thread.sleep(1000);
+
+        // 2. 스파이크 시작
+        BurstResult spike = executeBurst("스파이크", scheduleId, 5000, 1000);
+        results.add(spike);
+
+        Thread.sleep(1000);
+
+        // 3. 스파이크 후 안정화
+        BurstResult recovery = executeBurst("안정화", scheduleId, 100, 1000);
+        results.add(recovery);
+
+        // Then - 버스트 패턴 분석
+        log.info("");
+        log.info("=== 버스트 패턴 분석 ===");
+
+        for (BurstResult result : results) {
+            log.info("");
+            log.info("[{}]", result.phase);
+            log.info("   - 요청: {}", result.totalRequests);
+            log.info("   - 성공: {} ({}%)", result.successCount,
+                    result.successCount * 100.0 / result.totalRequests);
+            log.info("   - P95 응답: {}ms", result.p95ResponseTime);
+            log.info("   - TPS: {}", result.tps);
+        }
+
+        // 안정화 단계에서는 정상 복구되어야 함
+        assertThat(recovery.successCount * 100.0 / recovery.totalRequests)
+                .as("안정화 후 성공률 95% 이상")
+                .isGreaterThanOrEqualTo(90.0);
+    }
+
+    private BurstResult executeBurst(String phase, Long scheduleId, int requests, long durationMs)
+            throws InterruptedException {
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(requests);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        List<Long> responseTimes = new CopyOnWriteArrayList<>();
+
+        Instant startTime = Instant.now();
+
+        for (int i = 0; i < requests; i++) {
+            stressTestExecutor.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    long requestStart = System.currentTimeMillis();
+
+                    try {
+                        rankingUseCase.trackReservation(scheduleId, 1);
+
+                        long responseTime = System.currentTimeMillis() - requestStart;
+                        responseTimes.add(responseTime);
+                        successCount.incrementAndGet();
+
+                    } catch (Exception e) {
+                        failureCount.incrementAndGet();
+                    }
+
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        completionLatch.await(30, TimeUnit.SECONDS);
+        Duration duration = Duration.between(startTime, Instant.now());
+
+        long p95 = 0;
+        if (!responseTimes.isEmpty()) {
+            Collections.sort(responseTimes);
+            p95 = responseTimes.get((int)(responseTimes.size() * 0.95));
+        }
+
+        long tps = successCount.get() * 1000 / Math.max(1, duration.toMillis());
+
+        return new BurstResult(phase, requests, successCount.get(), failureCount.get(), p95, tps);
+    }
+
+    // Helper Classes
+    private static class LoadTestResult {
+        final int totalRequests;
+        final int successCount;
+        final int failureCount;
+        final long durationMs;
+        final List<Long> responseTimes;
+
+        LoadTestResult(int totalRequests, int successCount, int failureCount,
+                       long durationMs, List<Long> responseTimes) {
+            this.totalRequests = totalRequests;
+            this.successCount = successCount;
+            this.failureCount = failureCount;
+            this.durationMs = durationMs;
+            this.responseTimes = new ArrayList<>(responseTimes);
+        }
+    }
+
+    private static class BurstResult {
+        final String phase;
+        final int totalRequests;
+        final int successCount;
+        final int failureCount;
+        final long p95ResponseTime;
+        final long tps;
+
+        BurstResult(String phase, int totalRequests, int successCount, int failureCount,
+                    long p95ResponseTime, long tps) {
+            this.phase = phase;
+            this.totalRequests = totalRequests;
+            this.successCount = successCount;
+            this.failureCount = failureCount;
+            this.p95ResponseTime = p95ResponseTime;
+            this.tps = tps;
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/ranking/RankingCachePerformanceTest.java
+++ b/src/test/java/kr/hhplus/be/server/ranking/RankingCachePerformanceTest.java
@@ -258,8 +258,22 @@ class RankingCachePerformanceTest {
         log.info("11초 후 (캐시 만료): {}}ms", time2Ms);
         log.info("캐시 만료 후가 더 느림: {}", time2Ms > time1Ms);
 
-        // Then: 결과는 같지만, 11초 후는 다시 조회하므로 약간 더 느림
-        assertThat(result1).isEqualTo(result2);
+        // Then: 기본 정보는 같지만, velocityPerMinute는 시간에 따라 변함
+        assertThat(result1).hasSize(1);
+        assertThat(result2).hasSize(1);
+
+        ConcertRankingDto dto1 = result1.get(0);
+        ConcertRankingDto dto2 = result2.get(0);
+
+        // 변하지 않는 값들 검증
+        assertThat(dto1.scheduleId()).isEqualTo(dto2.scheduleId());
+        assertThat(dto1.soldCount()).isEqualTo(dto2.soldCount());
+
+        // velocityPerMinute는 시간이 지나면서 변해야 함 (캐시 만료 확인)
+        assertThat(dto1.velocityPerMinute()).isNotEqualTo(dto2.velocityPerMinute());
+
+        log.info("캐시 전 velocity: {}, 캐시 만료 후 velocity: {}",
+                dto1.velocityPerMinute(), dto2.velocityPerMinute());
 
         // 테스트 환경에서는 시간 차이가 미세할 수 있으므로
         // 단순히 11초 후 조회가 정상 동작하는지만 확인

--- a/src/test/java/kr/hhplus/be/server/ranking/RankingCachePerformanceTest.java
+++ b/src/test/java/kr/hhplus/be/server/ranking/RankingCachePerformanceTest.java
@@ -1,0 +1,270 @@
+package kr.hhplus.be.server.ranking;
+
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.port.in.RankingUseCase.ConcertRankingDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 캐싱 성능 테스트
+ *
+ * 검증 사항:
+ * 1. 첫 조회는 Redis에서 데이터를 가져옴
+ * 2. 두 번째 조회는 캐시에서 가져옴 - 더 빠름
+ * 3. 예약 추적 시 캐시가 무효화됨
+ * 4. 캐시 무효화 후 다시 조회하면 Redis에서 가져옴
+ */
+@Slf4j
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("랭킹 캐싱 성능 검증")
+class RankingCachePerformanceTest {
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(
+            DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port",
+                () -> redis.getMappedPort(6379).toString());
+    }
+
+    @Autowired
+    private RankingUseCase rankingUseCase;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        // Redis 초기화
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+
+        // 캐시 초기화
+        cacheManager.getCacheNames().forEach(cacheName ->
+                cacheManager.getCache(cacheName).clear()
+        );
+
+        log.info("테스트 환경 초기화 완료");
+    }
+
+    @Test
+    @DisplayName("첫 조회 vs 캐시된 조회 - 캐시가 더 빠름")
+    void test_캐시_성능_첫조회_vs_캐시조회() {
+        // Given: 랭킹 데이터 준비
+        for (int i = 1; i <= 5; i++) {
+            rankingUseCase.trackReservation((long) i, 10 * i);
+        }
+
+        // Warmup
+        rankingUseCase.getFastSellingRanking(10);
+
+        // When 1: 첫 조회]
+        cacheManager.getCache("concertRankings").clear();
+        long start1 = System.nanoTime();
+        List<ConcertRankingDto> result1 = rankingUseCase.getFastSellingRanking(10);
+        long time1 = System.nanoTime() - start1;
+
+        // When 2: 두 번째 조회 (캐시 히트)
+        long start2 = System.nanoTime();
+        List<ConcertRankingDto> result2 = rankingUseCase.getFastSellingRanking(10);
+        long time2 = System.nanoTime() - start2;
+
+        // When 3: 세 번째 조회 (캐시 히트)
+        long start3 = System.nanoTime();
+        List<ConcertRankingDto> result3 = rankingUseCase.getFastSellingRanking(10);
+        long time3 = System.nanoTime() - start3;
+
+        // Then
+        assertThat(result1).isEqualTo(result2).isEqualTo(result3);
+
+        double time1Ms = time1 / 1_000_000.0;
+        double time2Ms = time2 / 1_000_000.0;
+        double time3Ms = time3 / 1_000_000.0;
+        double avgCacheHitMs = (time2Ms + time3Ms) / 2;
+
+        log.info("=== 캐싱 성능 측정 ===");
+        log.info("첫 조회 (캐시 미스): {}ms", time1Ms);
+        log.info("두 번째 조회 (캐시 히트): {}ms", time2Ms);
+        log.info("세 번째 조회 (캐시 히트): {}ms", time3Ms);
+        log.info("평균 캐시 히트: {}ms", avgCacheHitMs);
+        log.info("성능 향상: {}배", time1Ms / avgCacheHitMs);
+
+        // 캐시 히트가 더 빠름
+        assertThat(avgCacheHitMs).isLessThan(time1Ms);
+    }
+
+    @Test
+    @DisplayName("예약 추적 시 캐시 무효화")
+    void test_예약_추적_시_캐시_무효화() {
+        // Given: 랭킹 데이터 준비 및 캐시
+        Long scheduleId = 1L;
+        rankingUseCase.trackReservation(scheduleId, 10);
+        List<ConcertRankingDto> beforeRanking = rankingUseCase.getFastSellingRanking(10);
+
+        // When: 예약 추가 (캐시 무효화 발생)
+        rankingUseCase.trackReservation(scheduleId, 20);
+
+        // Then: 새로 조회한 랭킹은 업데이트된 값을 반영
+        List<ConcertRankingDto> afterRanking = rankingUseCase.getFastSellingRanking(10);
+
+        assertThat(afterRanking).isNotEmpty();
+        ConcertRankingDto updated = afterRanking.get(0);
+        assertThat(updated.soldCount()).isEqualTo(30);  // 10 + 20
+
+        log.info("예약 추적 후 캐시 무효화 확인: {} -> {}",
+                beforeRanking.get(0).soldCount(), updated.soldCount());
+    }
+
+    @Test
+    @DisplayName("limit 값에 따라 별도 캐시 키 사용")
+    void test_limit값에_따라_별도_캐시() {
+        // Given: 10개 랭킹 데이터 준비
+        for (int i = 1; i <= 10; i++) {
+            rankingUseCase.trackReservation((long) i, i * 5);
+        }
+
+        // When: 다른 limit으로 조회
+        List<ConcertRankingDto> top5 = rankingUseCase.getFastSellingRanking(5);
+        List<ConcertRankingDto> top10 = rankingUseCase.getFastSellingRanking(10);
+
+        // Then: 서로 다른 결과
+        assertThat(top5).hasSize(5);
+        assertThat(top10).hasSize(10);
+        assertThat(top5).isNotEqualTo(top10);
+
+        log.info("Top 5와 Top 10은 별도로 캐싱됨");
+    }
+
+    @Test
+    @DisplayName("100회 조회 성능 - 캐싱 효과")
+    void test_100회_조회_캐싱_효과() {
+        // Given: 랭킹 데이터 준비
+        for (int i = 1; i <= 20; i++) {
+            rankingUseCase.trackReservation((long) i, i * 3);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            rankingUseCase.getFastSellingRanking(10);
+        }
+
+        // When: 100회 조회 (모두 캐시 히트여야 함)
+        long start = System.nanoTime();
+        for (int i = 0; i < 100; i++) {
+            rankingUseCase.getFastSellingRanking(10);
+        }
+        long totalTime = System.nanoTime() - start;
+
+        double avgTimeMs = totalTime / 100.0 / 1_000_000.0;
+        long totalTimeMs = totalTime / 1_000_000;
+
+        log.info("=== 100회 조회 성능 ===");
+        log.info("총 소요 시간: {}ms", totalTimeMs);
+        log.info("평균 응답 시간: {}ms", avgTimeMs);
+        log.info("TPS: {} req/s", 100_000.0 / totalTimeMs);
+
+        assertThat(avgTimeMs).isLessThan(3.0);  // 3ms 이내 (캐시 히트 기준)
+        assertThat(totalTimeMs).isLessThan(300);  // 전체 300ms 이내
+    }
+
+    @Test
+    @DisplayName("캐시 동작 확인 - 로그로 검증")
+    void test_캐시_동작_확인() {
+        // Given: 랭킹 데이터 준비
+        rankingUseCase.trackReservation(1L, 50);
+
+        log.info("=== 캐시 동작 검증 시작 ===");
+
+        // When 1: 첫 조회 (캐시 미스 - "Redis에서 데이터 조회" 로그 출력)
+        log.info(">>> 첫 번째 조회 (캐시 미스 예상)");
+        List<ConcertRankingDto> result1 = rankingUseCase.getFastSellingRanking(10);
+
+        // When 2: 두 번째 조회 (캐시 히트 - 로그 없음)
+        log.info(">>> 두 번째 조회 (캐시 히트 예상 - 로그 없어야 함)");
+        List<ConcertRankingDto> result2 = rankingUseCase.getFastSellingRanking(10);
+
+        // When 3: 세 번째 조회 (캐시 히트 - 로그 없음)
+        log.info(">>> 세 번째 조회 (캐시 히트 예상 - 로그 없어야 함)");
+        List<ConcertRankingDto> result3 = rankingUseCase.getFastSellingRanking(10);
+
+        log.info("=== 캐시 동작 검증 완료 ===");
+        log.info("결과: 첫 조회 후 '(캐시 미스)' 로그가 1번만 나왔다면 캐싱 정상 동작");
+
+        // Then: 같은 결과
+        assertThat(result1).isEqualTo(result2).isEqualTo(result3);
+    }
+
+    @Test
+    @DisplayName("캐시 TTL 검증 - 10초 후 만료")
+    void test_캐시_TTL_10초() throws InterruptedException {
+        // Given: 랭킹 데이터 준비 및 캐시
+        rankingUseCase.trackReservation(1L, 50);
+
+        // 첫 조회 (캐시 적재)
+        rankingUseCase.getFastSellingRanking(10);
+
+        log.info("=== TTL 검증 시작 ===");
+
+        // When 1: 5초 대기 (TTL 10초보다 짧음)
+        log.info(">>> 5초 대기 중... (캐시 유효)");
+        Thread.sleep(5000);
+
+        long start1 = System.nanoTime();
+        List<ConcertRankingDto> result1 = rankingUseCase.getFastSellingRanking(10);
+        long time1 = System.nanoTime() - start1;
+
+        // When 2: 추가 6초 대기 (총 11초, TTL 초과)
+        log.info(">>> 추가 6초 대기 중... (총 11초, 캐시 만료 예상)");
+        Thread.sleep(6000);
+
+        long start2 = System.nanoTime();
+        List<ConcertRankingDto> result2 = rankingUseCase.getFastSellingRanking(10);
+        long time2 = System.nanoTime() - start2;
+
+        double time1Ms = time1 / 1_000_000.0;
+        double time2Ms = time2 / 1_000_000.0;
+
+        log.info("=== TTL 검증 결과 ===");
+        log.info("5초 후 (캐시 유효): {}ms", time1Ms);
+        log.info("11초 후 (캐시 만료): {}}ms", time2Ms);
+        log.info("캐시 만료 후가 더 느림: {}", time2Ms > time1Ms);
+
+        // Then: 결과는 같지만, 11초 후는 다시 조회하므로 약간 더 느림
+        assertThat(result1).isEqualTo(result2);
+
+        // 테스트 환경에서는 시간 차이가 미세할 수 있으므로
+        // 단순히 11초 후 조회가 정상 동작하는지만 확인
+        assertThat(time2Ms).isLessThan(100.0);  // 너무 느리지 않으면 OK
+
+        log.info("TTL 동작 확인 완료");
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/ranking/TicketingScenarioTest.java
+++ b/src/test/java/kr/hhplus/be/server/ranking/TicketingScenarioTest.java
@@ -1,0 +1,728 @@
+package kr.hhplus.be.server.ranking;
+
+import kr.hhplus.be.server.application.port.in.PaymentUseCase;
+import kr.hhplus.be.server.application.port.in.QueueUseCase;
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.port.in.ReservationUseCase;
+import kr.hhplus.be.server.application.port.in.SeatQueryUseCase;
+import kr.hhplus.be.server.concurrency.config.TestTaskExecutorConfig;
+import kr.hhplus.be.server.domain.queue.QueueTokenNotActiveException;
+import kr.hhplus.be.server.domain.reservation.QueueTokenExpiredException;
+import kr.hhplus.be.server.domain.reservation.SeatAlreadyAssignedException;
+import kr.hhplus.be.server.domain.reservation.SeatAlreadyConfirmedException;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.entity.ConcertJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.entity.ConcertScheduleJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.repository.ConcertJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.repository.ConcertScheduleJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.entity.UserWalletJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.repository.UserWalletJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.queue.jpa.entity.QueueTokenJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.queue.jpa.repository.QueueTokenJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.user.jpa.entity.UserJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.user.jpa.repository.UserJpaRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * 전체 플로우 티켓팅 시나리오 테스트
+ *
+ * 포함 요소:
+ * 1. 대기열 토큰 발급 및 검증
+ * 2. 좌석 조회 (DB 읽기)
+ * 3. 좌석 임시 할당 (분산 락 + DB 쓰기)
+ * 4. 예약 확정 (트랜잭션 + 결제)
+ * 5. 랭킹 업데이트 (Redis)
+ *
+ * 실제 병목 지점:
+ * - DB 락 경합
+ * - 분산 락 대기 시간
+ * - 트랜잭션 커밋 지연
+ * - 네트워크 레이턴시
+ */
+@Slf4j
+@SpringBootTest
+@Import(TestTaskExecutorConfig.class)
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("티켓팅 전체 플로우")
+class TicketingScenarioTest {
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379).toString());
+    }
+
+    @Autowired private QueueUseCase queueUseCase;
+    @Autowired private ReservationUseCase reservationUseCase;
+    @Autowired private SeatQueryUseCase seatQueryUseCase;
+    @Autowired private PaymentUseCase paymentUseCase;
+    @Autowired private RankingUseCase rankingUseCase;
+
+    @Autowired private UserJpaRepository userRepository;
+    @Autowired private ConcertJpaRepository concertRepository;
+    @Autowired private ConcertScheduleJpaRepository scheduleRepository;
+    @Autowired private UserWalletJpaRepository walletRepository;
+    @Autowired private QueueTokenJpaRepository queueTokenRepository;
+    @Autowired private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    @Qualifier("extremeTestExecutor")
+    private TaskExecutor taskExecutor;
+
+    private Long concertScheduleId;
+    private static final int TOTAL_SEATS = 50;  // 실제 좌석 수
+    private static final long TICKET_PRICE = 10_000L;
+
+    @BeforeEach
+    void setUp() {
+        log.info("테스트 환경 초기화 시작");
+
+        // Redis 초기화
+        cleanupRedis();
+
+        // 콘서트 및 스케줄 생성
+        ConcertJpaEntity concert = new ConcertJpaEntity("인기 아이돌 콘서트");
+        concert = concertRepository.save(concert);
+
+        ConcertScheduleJpaEntity schedule = new ConcertScheduleJpaEntity(
+                concert,
+                LocalDate.now().plusDays(7),
+                TOTAL_SEATS
+        );
+        schedule = scheduleRepository.save(schedule);
+        concertScheduleId = schedule.getId();
+
+        log.info("테스트 데이터 준비 완료 - scheduleId: {}, 좌석: {}개", concertScheduleId, TOTAL_SEATS);
+    }
+
+    private void cleanupRedis() {
+        try {
+            Set<String> keys = redisTemplate.keys("*");
+            if (keys != null && !keys.isEmpty()) {
+                redisTemplate.delete(keys);
+            }
+        } catch (Exception e) {
+            log.warn("Redis 초기화 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 시나리오 : 200명 동시 접속
+     *
+     * - 200명이 대기열 토큰 받음
+     * - 50명만 활성화 (대기열 통과)
+     * - 50개 좌석을 놓고 경쟁
+     *
+     * 예상 결과:
+     * - 성공: 최대 50명 (좌석 수)
+     * - 대기열 차단: 150명
+     * - 좌석 경합 실패: ~10명
+     * - 평균 응답시간: 200-500ms
+     * - P99: 1-3초
+     */
+    @Test
+    @DisplayName("200명 동시 접속 → 대기열 → 50석 경쟁")
+    void 실제_티켓팅_전체_플로우_200명() throws InterruptedException {
+        // Given: 200명의 사용자 생성
+        int totalUsers = 200;
+        int activeQueueSize = 50;  // 대기열 활성화 인원
+
+        List<TestUser> users = createUsers(totalUsers);
+
+        log.info("=== 티켓 오픈 시작 ===");
+        log.info("총 신청자: {}명, 좌석: {}개, 활성 대기열: {}명",
+                totalUsers, TOTAL_SEATS, activeQueueSize);
+
+        // 대기열 토큰 발급
+        List<String> tokens = issueTokensForUsers(users);
+
+        // 일부만 활성화
+        activateTokens(tokens.subList(0, activeQueueSize));
+
+        // 결과 수집
+        CountDownLatch startSignal = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(totalUsers);
+
+        AtomicInteger queueBlockedCount = new AtomicInteger(0);
+        AtomicInteger seatQuerySuccess = new AtomicInteger(0);
+        AtomicInteger tempAssignSuccess = new AtomicInteger(0);
+        AtomicInteger confirmSuccess = new AtomicInteger(0);
+        AtomicInteger seatCompetitionFailed = new AtomicInteger(0);
+        AtomicInteger otherErrors = new AtomicInteger(0);
+
+        List<Long> responseTimes = new CopyOnWriteArrayList<>();
+        Map<String, String> errorCategories = new ConcurrentHashMap<>();
+
+        Instant overallStart = Instant.now();
+
+        // When: 1000명 동시 예약 시도
+        for (int i = 0; i < totalUsers; i++) {
+            final TestUser user = users.get(i);
+            final String token = tokens.get(i);
+            final int seatNumber = (i % TOTAL_SEATS) + 1;
+
+            taskExecutor.execute(() -> {
+                long startTime = System.currentTimeMillis();
+                try {
+                    startSignal.await();
+
+                    // 1. 대기열 검증
+                    boolean isActive = queueUseCase.isTokenActive(token);
+                    if (!isActive) {
+                        queueBlockedCount.incrementAndGet();
+                        errorCategories.put(user.userId.toString(), "QUEUE_BLOCKED");
+                        return;
+                    }
+
+                    // 2. 좌석 조회
+                    List<SeatQueryUseCase.SeatView> seats =
+                            seatQueryUseCase.getSeatsStatus(concertScheduleId, LocalDate.now().plusDays(7));
+                    seatQuerySuccess.incrementAndGet();
+
+                    // 3. 좌석 임시 할당
+                    ReservationUseCase.TemporaryAssignResult tempAssign =
+                            reservationUseCase.temporaryAssign(
+                                    new ReservationUseCase.TemporaryAssignCommand(
+                                            token,
+                                            concertScheduleId,
+                                            seatNumber
+                                    )
+                            );
+                    tempAssignSuccess.incrementAndGet();
+
+                    // 4. 예약 확정
+                    ReservationUseCase.ConfirmReservationResult confirmed =
+                            reservationUseCase.confirmReservation(
+                                    new ReservationUseCase.ConfirmReservationCommand(
+                                            token,
+                                            tempAssign.reservationId(),
+                                            UUID.randomUUID().toString()
+                                    )
+                            );
+                    confirmSuccess.incrementAndGet();
+
+                    // 5. 랭킹 업데이트
+                    rankingUseCase.trackReservation(concertScheduleId, 1);
+
+                    long responseTime = System.currentTimeMillis() - startTime;
+                    responseTimes.add(responseTime);
+
+                    log.debug("성공: userId={}, seat={}, time={}ms",
+                            user.userId, seatNumber, responseTime);
+
+                } catch (QueueTokenNotActiveException | QueueTokenExpiredException e) {
+                    queueBlockedCount.incrementAndGet();
+                    errorCategories.put(user.userId.toString(), "QUEUE_ERROR");
+                } catch (SeatAlreadyAssignedException | SeatAlreadyConfirmedException e) {
+                    seatCompetitionFailed.incrementAndGet();
+                    errorCategories.put(user.userId.toString(), "SEAT_TAKEN");
+                    log.debug("좌석 경합 실패: userId={}, error={}", user.userId, e.getMessage());
+                } catch (Exception e) {
+                    otherErrors.incrementAndGet();
+                    errorCategories.put(user.userId.toString(), e.getClass().getSimpleName());
+                    log.debug("기타 오류: userId={}, error={}", user.userId, e.getMessage());
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        // 티켓 오픈
+        Thread.sleep(100);
+        log.info("\n=== 티켓 오픈! ===\n");
+        startSignal.countDown();
+
+        boolean completed = completionLatch.await(60, TimeUnit.SECONDS);
+        assertThat(completed).isTrue();
+
+        Duration totalDuration = Duration.between(overallStart, Instant.now());
+
+        // Then: 결과 분석
+        printDetailedResults(
+                totalUsers, activeQueueSize,
+                queueBlockedCount.get(),
+                seatQuerySuccess.get(),
+                tempAssignSuccess.get(),
+                confirmSuccess.get(),
+                seatCompetitionFailed.get(),
+                otherErrors.get(),
+                responseTimes,
+                totalDuration,
+                errorCategories
+        );
+
+        // 검증
+        assertThat(confirmSuccess.get())
+                .as("확정된 예약은 좌석 수를 초과할 수 없음")
+                .isLessThanOrEqualTo(TOTAL_SEATS);
+
+        assertThat(confirmSuccess.get())
+                .as("최소 1개 이상의 예약은 성공해야 함")
+                .isGreaterThan(0);
+
+        assertThat(queueBlockedCount.get())
+                .as("대기열 차단은 (전체 - 활성) 인원 정도여야 함")
+                .isGreaterThanOrEqualTo(totalUsers - activeQueueSize - 50);  // 여유 50
+    }
+
+    /**
+     * 1000명 동시 접속 (부하 테스트용)
+     *
+     * ⚠️ 주의: 로컬 환경에서는 메모리 부족 발생 가능
+     *
+     * 극한 부하 시나리오:
+     * - 1000명이 대기열 토큰 받음
+     * - 100명만 활성화
+     * - 50개 좌석을 놓고 경쟁
+     *
+     * 예상 결과:
+     * - 성공: 최대 50명
+     * - 대기열 차단: 900명
+     * - 좌석 경합 실패: 50명
+     */
+    @Test
+    @Tag("load-test")  // 태그로 분리
+    @DisplayName("1000명 동시 접속 → 극한 부하 테스트")
+    void 실제_티켓팅_전체_플로우_1000명_부하테스트() throws InterruptedException {
+        // Given: 1000명의 사용자 생성
+        int totalUsers = 1000;
+        int activeQueueSize = 100;
+
+        List<TestUser> users = createUsers(totalUsers);
+
+        log.info("=== 극한 부하 테스트 시작 ===");
+        log.info("주의: 대량의 메모리와 DB 커넥션 사용");
+        log.info("총 신청자: {}명, 좌석: {}개, 활성 대기열: {}명",
+                totalUsers, TOTAL_SEATS, activeQueueSize);
+
+        // 대기열 토큰 발급
+        List<String> tokens = issueTokensForUsers(users);
+        activateTokens(tokens.subList(0, activeQueueSize));
+
+        // 결과 수집
+        CountDownLatch startSignal = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(totalUsers);
+
+        AtomicInteger queueBlockedCount = new AtomicInteger(0);
+        AtomicInteger seatQuerySuccess = new AtomicInteger(0);
+        AtomicInteger tempAssignSuccess = new AtomicInteger(0);
+        AtomicInteger confirmSuccess = new AtomicInteger(0);
+        AtomicInteger seatCompetitionFailed = new AtomicInteger(0);
+        AtomicInteger otherErrors = new AtomicInteger(0);
+
+        List<Long> responseTimes = new CopyOnWriteArrayList<>();
+        Map<String, String> errorCategories = new ConcurrentHashMap<>();
+
+        Instant overallStart = Instant.now();
+
+        // When: 1000명 동시 예약 시도
+        for (int i = 0; i < totalUsers; i++) {
+            final TestUser user = users.get(i);
+            final String token = tokens.get(i);
+            final int seatNumber = (i % TOTAL_SEATS) + 1;
+
+            taskExecutor.execute(() -> {
+                long startTime = System.currentTimeMillis();
+                try {
+                    startSignal.await();
+
+                    // 1. 대기열 검증
+                    boolean isActive = queueUseCase.isTokenActive(token);
+                    if (!isActive) {
+                        queueBlockedCount.incrementAndGet();
+                        errorCategories.put(user.userId.toString(), "QUEUE_BLOCKED");
+                        return;
+                    }
+
+                    // 2. 좌석 조회
+                    List<SeatQueryUseCase.SeatView> seats =
+                            seatQueryUseCase.getSeatsStatus(concertScheduleId, LocalDate.now().plusDays(7));
+                    seatQuerySuccess.incrementAndGet();
+
+                    // 3. 좌석 임시 할당
+                    ReservationUseCase.TemporaryAssignResult tempAssign =
+                            reservationUseCase.temporaryAssign(
+                                    new ReservationUseCase.TemporaryAssignCommand(
+                                            token,
+                                            concertScheduleId,
+                                            seatNumber
+                                    )
+                            );
+                    tempAssignSuccess.incrementAndGet();
+
+                    // 4. 예약 확정
+                    ReservationUseCase.ConfirmReservationResult confirmed =
+                            reservationUseCase.confirmReservation(
+                                    new ReservationUseCase.ConfirmReservationCommand(
+                                            token,
+                                            tempAssign.reservationId(),
+                                            UUID.randomUUID().toString()
+                                    )
+                            );
+                    confirmSuccess.incrementAndGet();
+
+                    // 5. 랭킹 업데이트
+                    rankingUseCase.trackReservation(concertScheduleId, 1);
+
+                    long responseTime = System.currentTimeMillis() - startTime;
+                    responseTimes.add(responseTime);
+
+                } catch (QueueTokenNotActiveException | QueueTokenExpiredException e) {
+                    queueBlockedCount.incrementAndGet();
+                    errorCategories.put(user.userId.toString(), "QUEUE_ERROR");
+                } catch (SeatAlreadyAssignedException | SeatAlreadyConfirmedException e) {
+                    seatCompetitionFailed.incrementAndGet();
+                    errorCategories.put(user.userId.toString(), "SEAT_TAKEN");
+                } catch (Exception e) {
+                    otherErrors.incrementAndGet();
+                    errorCategories.put(user.userId.toString(), e.getClass().getSimpleName());
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        Thread.sleep(100);
+        log.info("\n=== 티켓 오픈! ===\n");
+        startSignal.countDown();
+
+        boolean completed = completionLatch.await(120, TimeUnit.SECONDS);  // 타임아웃 증가
+        assertThat(completed).isTrue();
+
+        Duration totalDuration = Duration.between(overallStart, Instant.now());
+
+        // Then: 결과 분석
+        printDetailedResults(
+                totalUsers, activeQueueSize,
+                queueBlockedCount.get(),
+                seatQuerySuccess.get(),
+                tempAssignSuccess.get(),
+                confirmSuccess.get(),
+                seatCompetitionFailed.get(),
+                otherErrors.get(),
+                responseTimes,
+                totalDuration,
+                errorCategories
+        );
+
+        // 검증
+        assertThat(confirmSuccess.get())
+                .as("확정된 예약은 좌석 수를 초과할 수 없음")
+                .isLessThanOrEqualTo(TOTAL_SEATS);
+
+        assertThat(confirmSuccess.get())
+                .as("최소 1개 이상의 예약은 성공해야 함")
+                .isGreaterThan(0);
+
+        assertThat(queueBlockedCount.get())
+                .as("대기열 차단은 (전체 - 활성) 인원 정도여야 함")
+                .isGreaterThanOrEqualTo(totalUsers - activeQueueSize - 50);
+    }
+
+    /**
+     * 단계별 이탈 분석
+     */
+    @Test
+    @DisplayName("단계별 이탈률 분석")
+    void 사용자_파이프라인_분석_전체_플로우() throws InterruptedException {
+        // Given
+        int totalUsers = 100;
+        List<TestUser> users = createUsers(totalUsers);
+        List<String> tokens = issueTokensForUsers(users);
+        activateTokens(tokens);  // 전체 활성화
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(totalUsers);
+
+        AtomicInteger step1_queueCheck = new AtomicInteger(0);
+        AtomicInteger step2_seatView = new AtomicInteger(0);
+        AtomicInteger step3_tempAssign = new AtomicInteger(0);
+        AtomicInteger step4_confirm = new AtomicInteger(0);
+
+        Random random = new Random();
+
+        // When: 사용자 행동 시뮬레이션
+        for (int i = 0; i < totalUsers; i++) {
+            final TestUser user = users.get(i);
+            final String token = tokens.get(i);
+            final int seatNumber = random.nextInt(TOTAL_SEATS) + 1;
+
+            taskExecutor.execute(() -> {
+                try {
+                    startLatch.await();
+                    Thread.sleep(random.nextInt(100));  // 사용자 접속 시간 차이
+
+                    // 1. 대기열 확인 (100%)
+                    boolean isActive = queueUseCase.isTokenActive(token);
+                    step1_queueCheck.incrementAndGet();
+                    if (!isActive) return;
+
+                    // 2. 좌석 조회 (80% 진입)
+                    if (random.nextInt(100) < 80) {
+                        seatQueryUseCase.getSeatsStatus(concertScheduleId, LocalDate.now().plusDays(7));
+                        step2_seatView.incrementAndGet();
+                        Thread.sleep(random.nextInt(500));  // 고민 시간
+
+                        // 3. 임시 할당 시도 (60% 진입)
+                        if (random.nextInt(100) < 60) {
+                            try {
+                                var result = reservationUseCase.temporaryAssign(
+                                        new ReservationUseCase.TemporaryAssignCommand(
+                                                token, concertScheduleId, seatNumber
+                                        )
+                                );
+                                step3_tempAssign.incrementAndGet();
+                                Thread.sleep(random.nextInt(1000));  // 결제 고민
+
+                                // 4. 예약 확정 (70% 진입)
+                                if (random.nextInt(100) < 70) {
+                                    reservationUseCase.confirmReservation(
+                                            new ReservationUseCase.ConfirmReservationCommand(
+                                                    token,
+                                                    result.reservationId(),
+                                                    UUID.randomUUID().toString()
+                                            )
+                                    );
+                                    rankingUseCase.trackReservation(concertScheduleId, 1);
+                                    step4_confirm.incrementAndGet();
+                                }
+                            } catch (Exception e) {
+                            }
+                        }
+                    }
+
+                } catch (Exception e) {
+                    log.debug("사용자 {} 처리 중 오류: {}", user.userId, e.getMessage());
+                } finally {
+                    completionLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        completionLatch.await(30, TimeUnit.SECONDS);
+
+        // Then: 파이프라인 분석
+        printPipelineAnalysis(
+                totalUsers,
+                step1_queueCheck.get(),
+                step2_seatView.get(),
+                step3_tempAssign.get(),
+                step4_confirm.get()
+        );
+
+        assertThat(step1_queueCheck.get()).isEqualTo(totalUsers);
+        assertThat(step2_seatView.get()).isLessThan(step1_queueCheck.get());
+        assertThat(step3_tempAssign.get()).isLessThan(step2_seatView.get());
+        assertThat(step4_confirm.get()).isLessThan(step3_tempAssign.get());
+    }
+
+    private List<TestUser> createUsers(int count) {
+        List<TestUser> users = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            UUID userId = UUID.randomUUID();
+            String userName = "user_" + i + "_" + System.currentTimeMillis();
+
+            UserJpaEntity user = new UserJpaEntity(userId, userName);
+            userRepository.save(user);
+
+            UserWalletJpaEntity wallet = new UserWalletJpaEntity(userId, 1_000_000L);
+            walletRepository.save(wallet);
+
+            users.add(new TestUser(userId, userName));
+        }
+        log.info("{}명의 사용자 생성 완료", count);
+        return users;
+    }
+
+    private List<String> issueTokensForUsers(List<TestUser> users) {
+        List<String> tokens = new ArrayList<>();
+        for (TestUser user : users) {
+            QueueUseCase.TokenInfo tokenInfo = queueUseCase.issueToken(
+                    new QueueUseCase.IssueTokenCommand(user.userId.toString())
+            );
+            tokens.add(tokenInfo.token());
+        }
+        log.info("{}개의 대기열 토큰 발급 완료", tokens.size());
+        return tokens;
+    }
+
+    private void activateTokens(List<String> tokens) {
+        // MySQL 기반으로 직접 토큰 활성화
+        for (String token : tokens) {
+            try {
+                // QueueTokenJpaEntity를 직접 조회해서 활성화
+                Optional<QueueTokenJpaEntity> entityOpt =
+                        queueTokenRepository.findByToken(token);
+
+                if (entityOpt.isPresent()) {
+                    QueueTokenJpaEntity entity = entityOpt.get();
+                    if (entity.getStatus() == QueueTokenJpaEntity.TokenStatus.WAITING) {
+                        entity.activate();  // WAITING → ACTIVE
+                        queueTokenRepository.save(entity);
+                        log.debug("토큰 활성화 완료: {}", token);
+                    }
+                } else {
+                    log.warn("토큰을 찾을 수 없음: {}", token);
+                }
+            } catch (Exception e) {
+                log.error("토큰 활성화 실패: {}", token, e);
+            }
+        }
+        log.info("{}개의 토큰 활성화 완료", tokens.size());
+    }
+
+    private void printDetailedResults(
+            int totalUsers, int activeQueue,
+            int queueBlocked, int seatQuerySuccess, int tempAssignSuccess,
+            int confirmSuccess, int seatFailed, int otherErrors,
+            List<Long> responseTimes, Duration totalDuration,
+            Map<String, String> errorCategories
+    ) {
+        log.info("\n");
+        log.info("=".repeat(70));
+        log.info("티켓팅 전체 플로우 결과 분석");
+        log.info("=".repeat(70));
+        log.info("");
+
+        log.info("전체 소요 시간: {}ms ({}초)",
+                totalDuration.toMillis(), totalDuration.getSeconds());
+        log.info("");
+
+        log.info("단계별 처리 현황:");
+        log.info("총 시도:           {} 명", totalUsers);
+        log.info("대기열 통과:       {} 명 ({}%)",
+                activeQueue, activeQueue * 100 / totalUsers);
+        log.info("대기열 차단:       {} 명", queueBlocked);
+        log.info("좌석 조회 성공:    {} 명", seatQuerySuccess);
+        log.info("임시 할당 성공:    {} 명", tempAssignSuccess);
+        log.info("예약 확정 성공:    {} 명", confirmSuccess);
+        log.info("좌석 경합 실패:    {} 명", seatFailed);
+        log.info("기타 오류:         {} 명", otherErrors);
+        log.info("");
+
+        log.info("최종 전환율:");
+        double conversionRate = confirmSuccess * 100.0 / totalUsers;
+        double competitionRate = confirmSuccess * 100.0 / activeQueue;
+        double seatUtilization = confirmSuccess * 100.0 / TOTAL_SEATS;
+        log.info("전체 기준:     {}/{}명 = {}%",
+                confirmSuccess, totalUsers, String.format("%.1f", conversionRate));
+        log.info("활성 사용자 기준: {}/{}명 = {}%",
+                confirmSuccess, activeQueue, String.format("%.1f", competitionRate));
+        log.info("좌석 활용률:   {}/{}석 = {}%",
+                confirmSuccess, TOTAL_SEATS, String.format("%.0f", seatUtilization));
+        log.info("");
+
+        if (!responseTimes.isEmpty()) {
+            Collections.sort(responseTimes);
+            long avg = responseTimes.stream().mapToLong(Long::longValue).sum() / responseTimes.size();
+            long p50 = responseTimes.get(responseTimes.size() / 2);
+            long p95 = responseTimes.get((int)(responseTimes.size() * 0.95));
+            long p99 = responseTimes.get((int)(responseTimes.size() * 0.99));
+            long max = responseTimes.get(responseTimes.size() - 1);
+
+            log.info("응답 시간 분석 (성공한 요청만):");
+            log.info("평균:  {} ms", avg);
+            log.info("P50:   {} ms", p50);
+            log.info("P95:   {} ms", p95);
+            log.info("P99:   {} ms", p99);
+            log.info("Max:   {} ms", max);
+            log.info("");
+
+            double actualTps = confirmSuccess * 1000.0 / totalDuration.toMillis();
+            double totalTps = totalUsers * 1000.0 / totalDuration.toMillis();
+            log.info("처리량 (TPS):");
+            log.info("성공한 예약 TPS:  {} req/s", String.format("%.1f", actualTps));
+            log.info("전체 요청 TPS:    {} req/s", String.format("%.1f", totalTps));
+        }
+        log.info("");
+
+        // 오류 분류 통계
+        Map<String, Long> errorStats = new HashMap<>();
+        errorCategories.values().forEach(error ->
+                errorStats.merge(error, 1L, Long::sum)
+        );
+
+        if (!errorStats.isEmpty()) {
+            log.info("실패 원인 분석:");
+            errorStats.entrySet().stream()
+                    .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                    .forEach(entry -> log.info("   {}: {} 건", entry.getKey(), entry.getValue()));
+            log.info("");
+        }
+
+        log.info("=".repeat(70));
+        log.info("");
+    }
+
+    private void printPipelineAnalysis(
+            int total, int step1, int step2, int step3, int step4
+    ) {
+        log.info("\n");
+        log.info("=".repeat(70));
+        log.info("사용자 파이프라인 분석");
+        log.info("=".repeat(70));
+        log.info("");
+
+        log.info("단계별 전환:");
+        log.info("1. 대기열 확인:   {} 명 (100.0%)", step1);
+        log.info("2. 좌석 조회:     {} 명 ({:.1f}%)",
+                step2, step2 * 100.0 / step1);
+        log.info("3. 임시 할당:     {} 명 ({:.1f}%)",
+                step3, step3 * 100.0 / step2);
+        log.info("4. 예약 확정:     {} 명 ({:.1f}%)",
+                step4, step4 * 100.0 / step3);
+        log.info("");
+
+        log.info("단계별 이탈률:");
+        log.info("대기열 → 조회:  {}% 이탈",
+                (step1 - step2) * 100 / step1);
+        log.info("조회 → 할당:    {}% 이탈",
+                step2 > 0 ? (step2 - step3) * 100 / step2 : 0);
+        log.info("할당 → 확정:    {}% 이탈",
+                step3 > 0 ? (step3 - step4) * 100 / step3 : 0);
+        log.info("");
+
+        log.info("최종 전환율:    {:.1f}% ({}/{}명)",
+                step4 * 100.0 / total, step4, total);
+        log.info("");
+        log.info("=".repeat(70));
+        log.info("");
+    }
+
+    private record TestUser(UUID userId, String userName) {}
+}


### PR DESCRIPTION
- 주요 커밋:
  - 611055b: Redis 기반 콘서트 랭킹 시스템 구현 및 예약 서비스 연동
  - 06cf80c: 콘서트 랭킹 시스템 테스트
  - a5d86d7: 티켓팅 시나리오 테스트 추가
  - 0f97668: 랭킹 시스템에 캐싱 적용
  - 0ee77f5: 캐시 직렬화 오류 수정 및 테스트 통과
  - 4a02e8a: Redis 기반 대기열 시스템 구현
  - 921c752: 7주차 Redis 랭킹/대기열 시스템 회고 작성
  - 7b9f545: velocity 계산 단위를 분에서 초로 변경

## PR 설명
### 주요 구현 내용

**1. 빠른 매진 랭킹 시스템 (Ranking Design)**
- **Redis Sorted Set 기반 판매 속도 랭킹**
  - 초당 판매량(velocity) 계산: `soldCount / elapsedSeconds`
  - 티켓팅의 빠른 변화를 실시간으로 반영
  - 실시간 랭킹 자동 정렬
- **Redis Hash를 통한 스케줄 통계 저장**
  - soldCount, startTime, totalSeats, lastSaleTime 관리
  - HINCRBY로 원자적 판매 수량 증가
- **N+1 문제 해결**
  - `findAllByIds()` 배치 조회 구현
  - 10개 랭킹: 10번 쿼리 → 1번 쿼리로 개선

**2. Redis 대기열 시스템 (Asynchronous Design)**
- **원자적 카운터 기반 동시성 제어**
  - `increment/decrement`로 100명 제어
  - 분산락 없이 동시성 보장
- **Redis 분산락 구현**
  - `setIfAbsent(key, value, Duration)` 사용
  - unlock Race Condition 해결: TTL 자동 만료 방식 선택
- **Redis 자료구조 활용**
  - Sorted Set: 타임스탬프 score로 FIFO 대기열
  - Set: O(1) 활성 사용자 존재 확인
  - Hash: 토큰 정보(userId, status, issuedAt) 저장
  - String: 원자적 카운터
- **동시성 테스트 검증**
  - 150명 동시 요청 → 정확히 100명 활성화, 50명 대기


## 리뷰 포인트

#### 1. 분산락 unlock 구현 방식 (커밋: 4a02e8a)

```java
public <T> T executeWithLock(
            String lockKey,
            long ttlSeconds,
            int retryCount,
            long retryDelayMillis,
            Supplier<T> action
    ) {
        String lockValue = UUID.randomUUID().toString();
        int attempts = 0;

        while (attempts < retryCount) {
            boolean acquired = tryLock(lockKey, lockValue, ttlSeconds);

            if (acquired) {
                try {
                    log.info("락 획득 성공: key={}, value={}", lockKey, lockValue);
                    return action.get();
                } finally {
                    // unlock 호출 제거 - TTL로 자동 만료
                    // unlock의 race condition을 피하기 위해 명시적 해제를 하지 않음
                    log.info("락은 TTL({}초)로 자동 만료됨: key={}", ttlSeconds, lockKey);
                }
            }

            attempts++;
            if (attempts < retryCount) {
                log.info("락 획득 실패, 재시도 {}/{}: key={}", attempts, retryCount, lockKey);
                sleep(retryDelayMillis);
            }
        }

        throw LockAcquisitionException.of(lockKey, retryCount);
    }
```

**질문**
- 시나리오 처리 시간 < TTL이라 TTL 방식을 선택했는데, 실무에서도 이런 식으로 Trade-off를 고려하나요?
- 네트워크 지연 등의 이유로 TTL을 초과할 가능성이 있는데, 이럴 경우에 어떻게 해야하는지 궁금합니다.
---

#### 2. N+1 해결 시 부분 실패 처리 (커밋: 611055b)

```java
@Cacheable(value = "concertRankings", key = "#limit")
    public List<ConcertRankingDto> getFastSellingRanking(int limit) {
        log.debug("랭킹 조회 - Port를 통한 데이터 조회 (캐시 미스)");

        // Port를 통해 상위 랭킹 조회
        Set<String> topSchedules = rankingPort.getTopByVelocity(limit);

        if (topSchedules.isEmpty()) {
            return List.of();
        }

        // 1. scheduleId 목록 추출
        List<Long> scheduleIds = topSchedules.stream()
                .map(this::extractScheduleId)
                .filter(Objects::nonNull)
                .toList();

        // 2. 배치로 한 번에 조회
        Map<Long, ConcertSchedule> scheduleMap = schedulePort.findAllByIds(scheduleIds);

        // 3. 랭킹 데이터 조합
        List<ConcertRankingDto> result = new ArrayList<>();
        int rank = 1;

        for (String scheduleKey : topSchedules) {
            try {
                Long scheduleId = extractScheduleId(scheduleKey);
                if (scheduleId == null) continue;

                Map<String, String> stats = rankingPort.getStats(String.valueOf(scheduleId));
                if (stats.isEmpty()) continue;

                // 통계 정보 추출
                int soldCount = getIntValue(stats.get("soldCount"));
                double velocity = calculateVelocity(stats);
                boolean isSoldOut = stats.containsKey("soldOutTime");
                Integer soldOutSeconds = isSoldOut ?
                        getIntValue(stats.get("soldOutSeconds")) : null;

                // Map에서 조회
                String concertName = Optional.ofNullable(scheduleMap.get(scheduleId))
                        .map(schedule -> "Concert #" + scheduleId)
                        .orElse("Unknown Concert #" + scheduleId);

                result.add(new ConcertRankingDto(
                        rank++,
                        scheduleId,
                        concertName,
                        soldCount,
                        velocity,
                        isSoldOut,
                        soldOutSeconds
                ));

            } catch (NumberFormatException e) {
                log.warn("숫자 형식 오류 - scheduleKey: {}", scheduleKey);
            } catch (Exception e) {
                log.error("랭킹 항목 처리 실패 - scheduleKey: {}", scheduleKey, e);
            }
        }

        return result;
    }
```

**질문**
- 일부 항목이 실패해도 나머지 랭킹은 반환하도록 구현했는데, 이런 전략이 적절한지 궁금합니다.

---

#### 3. 원자적 카운터만으로 동시성 제어 (커밋: 4a02e8a)

```java
// 원자적 카운터로 동시성 제어
        Long currentCount = redisTemplate.opsForValue().increment("queue:active:counter");

        if (currentCount != null && currentCount <= MAX_ACTIVE_USERS) {
            // 100명 이내면 활성화
            activateToken(token);
            log.info("토큰 발급 완료: userId={}, activated=true", userId);
        } else {
            // 초과하면 카운터 롤백하고 대기열 추가
            redisTemplate.opsForValue().decrement("queue:active:counter");
            redisTemplate.opsForZSet().add(WAITING_QUEUE, token, (double) timestamp);
            redisTemplate.opsForHash().put(TOKEN_INFO + token, "status", "WAITING");
            log.info("토큰 발급 완료: userId={}, activated=false", userId);
        }
```

**질문**
- increment-check-activate가 원자적이지 않은데도 정확하게 동작하는 이유가 Redis 싱글 스레드 + 초과 시 즉시 롤백 때문이 맞을까요? 이 방식이 적절한지 궁금합니다.
