### PR TITLE
[STEP-8] 이벤트 기반 아키텍처 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# 언제 실행?
+on:
+  # PR 생성하거나 업데이트할 때
+  pull_request:
+    branches: [ main, develop ]
+
+  # main 브랜치에 push할 때
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: 테스트 실행
+    runs-on: ubuntu-latest  # GitHub이 제공하는 Ubuntu 서버
+
+    steps:
+      # 1. 코드 가져오기
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
+
+      # 2. Java 17 설치
+      - name: Java 17 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'  # Gradle 캐시로 빌드 속도 향상
+
+      # 3. Gradle 실행 권한 부여
+      - name: Gradle 실행 권한 부여
+        run: chmod +x gradlew
+
+      # 4. 테스트 실행
+      - name: 테스트 실행
+        run: ./gradlew test
+
+      # 5. 테스트 결과 리포트
+      - name: 테스트 결과 업로드
+        uses: actions/upload-artifact@v4
+        if: always()  # 성공/실패 상관없이 항상 실행
+        with:
+          name: test-results
+          path: build/reports/tests/test/
+          retention-days: 7  # 7일간 보관

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,46 +1,65 @@
 name: CI
 
-# 언제 실행?
 on:
-  # PR 생성하거나 업데이트할 때
+  push:
+    branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
 
-  # main 브랜치에 push할 때
-  push:
-    branches: [ main ]
-
 jobs:
   test:
-    name: 테스트 실행
-    runs-on: ubuntu-latest  # GitHub이 제공하는 Ubuntu 서버
+    runs-on: ubuntu-latest
+
+    services:
+      # MySQL
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: hhplus
+          MYSQL_ROOT_HOST: '%'
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+      # Redis
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
-      # 1. 코드 가져오기
-      - name: 코드 체크아웃
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Java 17 설치
-      - name: Java 17 설치
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
           java-version: '17'
-          cache: 'gradle'  # Gradle 캐시로 빌드 속도 향상
+          distribution: 'temurin'
+          cache: gradle
 
-      # 3. Gradle 실행 권한 부여
-      - name: Gradle 실행 권한 부여
+      - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # 4. 테스트 실행
-      - name: 테스트 실행
+      - name: Run tests
         run: ./gradlew test
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
-      # 5. 테스트 결과 리포트
-      - name: 테스트 결과 업로드
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
-        if: always()  # 성공/실패 상관없이 항상 실행
         with:
           name: test-results
           path: build/reports/tests/test/
-          retention-days: 7  # 7일간 보관
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # Testcontainers를 위한 권한
+    permissions:
+      contents: read
+      packages: read
+
     services:
-      # MySQL
       mysql:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
           MYSQL_DATABASE: hhplus
-          MYSQL_ROOT_HOST: '%'
         ports:
           - 3306:3306
         options: >-
@@ -26,7 +29,6 @@ jobs:
           --health-timeout=5s
           --health-retries=3
 
-      # Redis
       redis:
         image: redis:7-alpine
         ports:
@@ -48,6 +50,10 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -55,6 +61,7 @@ jobs:
         run: ./gradlew test
         env:
           SPRING_PROFILES_ACTIVE: test
+          TESTCONTAINERS_RYUK_DISABLED: false
 
       - name: Upload test results
         if: always()

--- a/docs/MSA_전환_설계문서.md
+++ b/docs/MSA_전환_설계문서.md
@@ -1,0 +1,301 @@
+# MSA 전환 설계
+
+## 1. 배포 단위 설계
+
+### 1.1 서비스 분리
+
+**6개 독립 서비스로 분리**
+
+| 서비스 | 책임 | 저장소 | 분리 이유 |
+|--------|------|--------|----------|
+| Queue | 대기열 관리 | Redis, MySQL | 트래픽 집중, 독립 확장 필수 |
+| Concert | 콘서트/좌석 관리 | MySQL, Redis | 읽기 트래픽 많음, 캐싱 최적화 |
+| Reservation | 예약 처리 | MySQL | 핵심 비즈니스, Saga 조율 |
+| Payment | 결제/지갑 | MySQL | 금전 관련, 독립 관리 필요 |
+| User | 사용자/인증 | MySQL | 독립성 높음 |
+| Ranking | 실시간 랭킹 | Redis, MySQL | 이벤트 기반, 느슨한 결합 |
+
+### 1.2 분리 근거
+
+**Bounded Context**
+```
+domain.queue       → Queue Service
+domain.concert     → Concert Service
+domain.reservation → Reservation Service
+domain.payment     → Payment Service
+```
+각 도메인은 이미 독립적인 용어와 규칙을 가지고 있어 Bounded Context로 적합합니다.
+
+**확장성 요구**
+
+현재 병목:
+```java
+private static final int MAX_ACTIVE_USERS = 100;
+
+// 동시성 테스트 결과
+150명 요청 → 100명 활성(67%), 50명 대기(33%)
+실제 예상: 10,000명 → 100명 활성(1%), 9,900명 대기(99%)
+```
+
+Queue Service를 독립 분리하여 Pod 10개로 확장 시 1,000명 동시 처리 가능
+
+---
+
+## 2. 트랜잭션 처리의 한계
+
+### 2.1 현재 모놀리식
+
+**하나의 트랜잭션으로 4개 도메인 처리**
+```java
+// ReservationService.confirmReservation()
+distributedLock.executeWithLock(
+    lockKey, 10L, 3, 100L,
+    () -> transactionTemplate.execute(status -> {
+        
+        // 1. Payment: 결제 (DB)
+        paymentUseCase.pay(new PaymentCommand(
+            userId.asString(),
+            reservation.getPrice().amount(),
+            command.idempotencyKey()
+        ));
+        
+        // 2. Reservation: 확정 (DB)
+        reservation.confirm(LocalDateTime.now());
+        reservationRepository.save(reservation);
+        
+        // 3. Concert: 좌석 해제 (Redis)
+        seatHoldPort.release(reservation.getSeatIdentifier());
+        
+        // 4. Queue: 토큰 만료 (Redis)
+        queuePort.expire(command.queueToken());
+        // Redis 내부 동작:
+        // - active counter 감소
+        // - ACTIVE_SET에서 제거
+        // - WAITING_QUEUE에서 제거
+        // - token 정보 삭제
+        
+        // 5. Event: 랭킹 업데이트 (비동기)
+        eventPublisher.publishEvent(
+            ReservationConfirmedEvent.of(...)
+        );
+        
+        return result;
+    })
+);
+```
+
+**특징**
+- 분산락 → DB 트랜잭션 순서로 실행
+- Payment, Reservation은 MySQL (ACID 보장)
+- Concert, Queue는 Redis (원자적 연산)
+- 4개 도메인이 하나의 흐름에서 처리
+
+### 2.2 MSA 전환 후
+
+**독립된 트랜잭션**
+```
+Payment Service    (독립 DB) → Transaction A
+   ↓ HTTP
+Reservation Service (독립 DB) → Transaction B
+   ↓ HTTP
+Concert Service    (독립 DB) → Transaction C
+   ↓ HTTP
+Queue Service      (독립 DB) → Transaction D
+```
+
+전체를 하나의 트랜잭션으로 묶을 수 없음.
+
+### 2.3 ACID 한계
+
+**Atomicity**
+```
+Payment 성공 → Reservation 실패
+결과: 돈은 빠져나갔는데 예약 안 됨
+```
+부분 실패 시 자동 롤백 불가능.
+
+**Consistency**
+```
+예약 확정 완료 → Ranking 업데이트 지연 (1~2초)
+결과: 일시적으로 랭킹 부정확
+```
+모든 서비스에서 Strong Consistency 보장 불가능.
+
+**Isolation**
+```
+서비스 A: 데이터 조회
+서비스 B: 동시에 데이터 변경
+서비스 A: 변경된 데이터로 저장
+결과: Lost Update
+```
+독립 트랜잭션으로 전체 격리 수준 보장 불가능.
+
+**Durability**
+```
+DB 저장 성공 → 이벤트 발행 실패
+결과: 예약은 저장됐는데 랭킹 미반영
+```
+DB 커밋과 메시지 발행을 원자적으로 처리 불가능.
+
+### 2.4 주요 시나리오
+
+**시나리오 1: 부분 실패**
+```
+Payment → Reservation → Concert → Queue
+문제: 토큰이 살아있어 중복 예약 가능
+```
+
+**시나리오 2: 타임아웃 애매모호**
+```
+Reservation → Payment 호출 (3초 타임아웃)
+케이스 A: Payment 성공했지만 응답만 늦음
+케이스 B: Payment 실제 실패
+
+문제: 재시도하면 중복 결제, 안 하면 사용자 불만
+```
+
+**시나리오 3: 보상 실패**
+```
+Payment → Reservation → Payment 환불 시도
+문제: 돈 빠져나갔는데 환불도 안 됨
+```
+
+**시나리오 4: 이벤트 순서 역전**
+```
+이벤트 1: 예약 확정 (10:00:00.100)
+이벤트 2: 예약 취소 (10:00:00.200)
+Ranking 수신: 2 먼저 → 1 나중
+
+문제: 취소했는데 랭킹 올라감
+```
+
+---
+
+## 3. 해결 방안
+
+### 3.1 Orchestration
+
+**선택 이유**
+- 4개 서비스의 순차적 협력 필요
+- 명확한 흐름 파악
+- 보상 트랜잭션 관리 용이
+
+**실행 흐름**
+```
+Reservation Service (Orchestrator)
+    ↓
+1. Payment 호출 → 결제
+    ↓ 성공
+2. Reservation 확정 → 저장
+    ↓ 성공
+3. Concert 호출 → 좌석 해제
+    ↓ 성공
+4. Queue 호출 → 토큰 만료
+    ↓ 성공
+5. Event 발행 → 랭킹 (비동기)
+```
+
+**보상 전략**
+
+| 실패 지점 | 보상 작업 |
+|---------|----------|
+| Step 1 | 보상 불필요 |
+| Step 2 | Payment 환불 |
+| Step 3 | Reservation 취소 + Payment 환불 |
+| Step 4 | Concert 재점유 + Reservation 취소 + Payment 환불 |
+
+보상 실패 시: Dead Letter Queue + 관리자 알림 + 수동 개입
+
+### 3.2 멱등성 보장
+
+**문제**
+```
+사용자 버튼 2번 클릭 / 네트워크 재시도 → 중복 결제
+```
+
+**해결**
+
+1. 클라이언트: 요청마다 고유 Idempotency Key 생성
+2. 서버: Redis에 키 + 결과 저장 (24시간 TTL)
+3. 동일 키 재요청 시 캐시 반환
+
+각 서비스 적용:
+- Reservation: API 레벨 검증
+- Payment: Saga ID를 키로 사용, DB unique 제약
+- Concert/Queue: 요청 키로 중복 방지
+
+### 3.3 Outbox Pattern
+
+**문제**
+```
+DB 저장 성공 → 메시지 브로커 장애 → 이벤트 미발행
+```
+
+**해결**
+
+**동작 방식**
+1. Reservation + Outbox Event를 같은 트랜잭션에 저장
+2. 스케줄러(1초마다)가 미발행 이벤트 조회
+3. Kafka로 발행 시도
+4. 성공 시 processed=true, 실패 시 재시도
+
+**Outbox 테이블**
+```
+outbox_events
+- id, aggregate_type, aggregate_id
+- event_type, payload, processed
+- created_at, processed_at
+```
+
+**장점**
+- At-Least-Once 보장
+- DB-메시지 원자성 확보
+- 장애 시에도 유실 없음
+
+### 3.4 Eventual Consistency
+
+**일관성 구분**
+
+| 도메인 | 일관성 | 이유 |
+|--------|--------|------|
+| Payment | Strong | 결제 금액 즉시 정확 |
+| Reservation | Strong | 예약 상태 즉시 정확 |
+| Concert | Strong | 좌석 점유 즉시 정확 |
+| Queue | Strong | 토큰 활성화 즉시 정확 |
+| Ranking | Eventual | 1~2초 지연 허용 |
+
+**이벤트 순서 문제**
+
+해결:
+- 이벤트에 version/timestamp 포함
+- Ranking Service에서 늦게 도착한 이벤트 무시
+- Redis에 마지막 처리 버전 저장
+
+---
+
+## 4. 정리
+
+### 4.1 트레이드오프
+
+| 항목 | 모놀리식 | MSA |
+|------|---------|-----|
+| 트랜잭션 | ACID | Eventual |
+| 배포 | 전체 | 독립 |
+| 확장 | 전체 | 서비스별 |
+| 복잡도 | 낮음 | 높음 |
+
+### 4.2 핵심 해결 방안
+
+```
+분산 트랜잭션 → Saga Orchestration
+중복 요청    → Idempotency Key
+이벤트 유실   → Outbox Pattern
+일관성 완화   → Eventual Consistency
+```
+
+### 4.3 남은 과제
+
+- Saga 보상 실패 시 수동 개입 프로세스
+- 주기적 정합성 검증 배치
+- 분산 추적 및 모니터링
+- Dead Letter Queue 관리

--- a/src/main/java/kr/hhplus/be/server/application/event/ReservationCancelledEvent.java
+++ b/src/main/java/kr/hhplus/be/server/application/event/ReservationCancelledEvent.java
@@ -1,0 +1,47 @@
+package kr.hhplus.be.server.application.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 예약 취소 완료 이벤트
+ *
+ * 발행 시점: 예약 취소 트랜잭션 커밋 후 (AFTER_COMMIT)
+ *
+ * 처리 작업:
+ * - 랭킹 시스템에서 예약 수 차감
+ * - 데이터 플랫폼으로 취소 정보 전송
+ * - (향후 확장) 알림톡, 이메일 발송 등
+ *
+ * 일관성 유지:
+ * - ReservationConfirmedEvent와 동일한 구조
+ * - 이벤트 기반 아키텍처의 일관된 패턴 적용
+ */
+public record ReservationCancelledEvent(
+        String reservationId,
+        String userId,
+        Long scheduleId,
+        Integer seatNumber,
+        Long price,
+        LocalDateTime cancelledAt
+) {
+    /**
+     * 예약 정보로부터 취소 이벤트 생성
+     */
+    public static ReservationCancelledEvent of(
+            String reservationId,
+            String userId,
+            Long scheduleId,
+            Integer seatNumber,
+            Long price,
+            LocalDateTime cancelledAt
+    ) {
+        return new ReservationCancelledEvent(
+                reservationId,
+                userId,
+                scheduleId,
+                seatNumber,
+                price,
+                cancelledAt
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/event/ReservationConfirmedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/application/event/ReservationConfirmedEvent.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.application.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 예약 확정 완료 이벤트
+ *
+ * - 예약 확정 트랜잭션 커밋 후 발행
+ * - 데이터 플랫폼 전송 등 부가 기능 트리거
+ */
+public record ReservationConfirmedEvent(
+        String reservationId,
+        String userId,
+        Long scheduleId,
+        Integer seatNumber,
+        Long price,
+        LocalDateTime confirmedAt
+) {
+    /**
+     * 예약 정보로부터 이벤트 생성
+     */
+    public static ReservationConfirmedEvent of(
+            String reservationId,
+            String userId,
+            Long scheduleId,
+            Integer seatNumber,
+            Long price,
+            LocalDateTime confirmedAt
+    ) {
+        return new ReservationConfirmedEvent(
+                reservationId,
+                userId,
+                scheduleId,
+                seatNumber,
+                price,
+                confirmedAt
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/event/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/application/event/ReservationEventListener.java
@@ -51,6 +51,106 @@ public class ReservationEventListener {
     }
 
     /**
+     * 예약 취소 시 랭킹 시스템 업데이트
+     *
+     * 실행 시점: 트랜잭션 커밋 후 (AFTER_COMMIT)
+     * 실행 방식: 비동기 (@Async)
+     * 실패 처리: 로그 남기고 무시
+     *
+     * 일관성 유지:
+     * - updateRanking과 동일한 패턴
+     * - 취소 시에도 이벤트 기반으로 처리
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateRankingOnCancel(ReservationCancelledEvent event) {
+        try {
+            log.info("═══════════════════════════════════════");
+            log.info("📉 [Ranking] 취소로 인한 랭킹 차감 시작");
+            log.info("예약 ID: {}, 공연 일정 ID: {}", event.reservationId(), event.scheduleId());
+            log.info("═══════════════════════════════════════");
+
+            rankingUseCase.decrementReservation(
+                    event.scheduleId(),
+                    1  // 취소된 좌석 수
+            );
+
+            log.info("✅ [Ranking] 랭킹 차감 완료 - reservationId: {}", event.reservationId());
+
+        } catch (Exception e) {
+            // 실패해도 핵심 비즈니스(예약 취소)는 이미 성공
+            // 운영팀에서 에러 로그를 확인하고 수동으로 보완하거나
+            // Slack 알림, Sentry 등으로 에러 전파 필요 (TODO: Step 16+)
+            log.error("⚠️  [Ranking] 랭킹 차감 실패 - reservationId: {}, scheduleId: {}, userId: {}, error: {}",
+                    event.reservationId(),
+                    event.scheduleId(),
+                    event.userId(),
+                    e.getMessage(),
+                    e);
+        }
+    }
+
+    /**
+     * 예약 취소 시 데이터 플랫폼으로 전송
+     *
+     * @param event 예약 취소 이벤트
+     *
+     * <p>실행 시점: 트랜잭션 커밋 후 (AFTER_COMMIT)
+     * <p>실행 방식: 비동기 (@Async)
+     * <p>실패 처리: 로그만 남기고 무시
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendCancellationToDataPlatform(ReservationCancelledEvent event) {
+        try {
+            log.info("═══════════════════════════════════════");
+            log.info("📤 [Data Platform] 취소 정보 전송 시작");
+            log.info("예약 ID: {}, 사용자 ID: {}", event.reservationId(), event.userId());
+            log.info("═══════════════════════════════════════");
+
+            // Mock API 호출
+            sendMockCancellationApi(event);
+
+            log.info("✅ [Data Platform] 취소 정보 전송 완료 - reservationId: {}", event.reservationId());
+
+        } catch (Exception e) {
+            log.error("⚠️  [Data Platform] 취소 정보 전송 실패 - reservationId: {}, userId: {}, scheduleId: {}, error: {}",
+                    event.reservationId(),
+                    event.userId(),
+                    event.scheduleId(),
+                    e.getMessage(),
+                    e);
+        }
+    }
+
+    /**
+     * Mock 취소 데이터 플랫폼 API 호출
+     */
+    private void sendMockCancellationApi(ReservationCancelledEvent event) {
+        log.info("""
+        
+        ╔════════════════════════════════════════════════╗
+        ║     Mock Data Platform API 호출 (취소)       ║
+        ╠════════════════════════════════════════════════╣
+        ║ 📋 예약 ID      : {}
+        ║ 👤 사용자 ID    : {}
+        ║ 🎭 공연 일정 ID : {}
+        ║ 💺 좌석 번호    : {}
+        ║ 💰 환불 금액    : {:,}원
+        ║ ⏰ 취소 시각    : {}
+        ║ ⚠️  상태        : CANCELLED
+        ╚════════════════════════════════════════════════╝
+        """,
+                event.reservationId(),
+                event.userId(),
+                event.scheduleId(),
+                event.seatNumber(),
+                event.price(),
+                event.cancelledAt()
+        );
+    }
+
+    /**
      * 예약 확정 완료 시 데이터 플랫폼으로 전송
      *
      * @param event 예약 확정 이벤트

--- a/src/main/java/kr/hhplus/be/server/application/event/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/application/event/ReservationEventListener.java
@@ -1,0 +1,109 @@
+package kr.hhplus.be.server.application.event;
+
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 예약 이벤트 리스너
+ *
+ * - 예약 확정 완료 시 부가 기능들을 수행
+ * - 트랜잭션 커밋 후 비동기 실행
+ * - 실패해도 핵심 비즈니스(예약 확정)에는 영향 없음
+ *
+ * 관심사 분리:
+ * - 핵심 로직(예약 확정): ReservationService에서 트랜잭션으로 처리
+ * - 부가 로직: EventListener에서 비동기로 처리
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationEventListener {
+
+    private final RankingUseCase rankingUseCase;
+
+    // 예약 확정 시 랭킹 시스템 업데이트
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void updateRanking(ReservationConfirmedEvent event) {
+        try {
+            log.info("═══════════════════════════════════════");
+            log.info("[Ranking] 랭킹 업데이트 시작");
+            log.info("공연 일정 ID: {}", event.scheduleId());
+            log.info("═══════════════════════════════════════");
+
+            rankingUseCase.trackReservation(
+                    event.scheduleId(),
+                    1  // 예약된 좌석 수
+            );
+
+            log.info("[Ranking] 랭킹 업데이트 완료");
+
+        } catch (Exception e) {
+            // 실패해도 예약 확정은 이미 성공
+            log.warn("⚠️  [Ranking] 랭킹 업데이트 실패 (무시) - scheduleId: {}, error: {}",
+                    event.scheduleId(), e.getMessage());
+        }
+    }
+
+    /**
+     * 예약 확정 완료 시 데이터 플랫폼으로 전송
+     *
+     * @param event 예약 확정 이벤트
+     *
+     * 실행 시점: 트랜잭션 커밋 후
+     * 실행 방식: 비동기
+     * 실패 처리: 로그만 남기고 무시
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendToDataPlatform(ReservationConfirmedEvent event) {
+        try {
+            log.info("═══════════════════════════════════════");
+            log.info("[Data Platform] 예약 정보 전송 시작");
+            log.info("예약 ID: {}", event.reservationId());
+            log.info("═══════════════════════════════════════");
+
+            // Mock API 호출 (실제로는 외부 API 또는 메시지 큐)
+            sendMockDataPlatformApi(event);
+
+            log.info("[Data Platform] 전송 완료");
+
+        } catch (Exception e) {
+            // 실패해도 핵심 비즈니스(예약 확정)는 이미 성공했으므로 무시
+            log.warn("[Data Platform] 전송 실패 (무시) - reservationId: {}, error: {}",
+                    event.reservationId(), e.getMessage());
+        }
+    }
+
+    /**
+     * Mock 데이터 플랫폼 API 호출
+     *
+     * <p>실제 구현 시:
+     * - REST API 호출: RestTemplate, WebClient 등
+     * - 메시지 큐: Kafka, RabbitMQ 등
+     * - 배치 처리: 실패 건 재시도 로직 등
+     */
+    private void sendMockDataPlatformApi(ReservationConfirmedEvent event) {
+        log.info("""
+            [ Mock Data Platform API 호출 ]
+            예약 ID      : {}
+            사용자 ID    : {}
+             공연 일정 ID : {}
+            좌석 번호    : {}
+             결제 금액    : {:,}원
+            확정 시각    : {}
+            """,
+                event.reservationId(),
+                event.userId(),
+                event.scheduleId(),
+                event.seatNumber(),
+                event.price(),
+                event.confirmedAt()
+        );
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/port/in/PaymentUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/in/PaymentUseCase.java
@@ -4,11 +4,13 @@ public interface PaymentUseCase {
 
     record ChargeCommand(String userId, long amount, String idempotencyKey) {}
     record PaymentCommand(String userId, long amount, String idempotencyKey) {}
+    record RefundCommand(String userId, long amount, String idempotencyKey) {}
     record BalanceQuery(String userId) {}
 
     record BalanceResult(long balance) {}
 
     BalanceResult charge(ChargeCommand command);
     BalanceResult pay(PaymentCommand command);
+    BalanceResult refund(RefundCommand command);
     BalanceResult getBalance(BalanceQuery query);
 }

--- a/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/in/RankingUseCase.java
@@ -8,6 +8,9 @@ public interface RankingUseCase {
     // 예약 추적
     void trackReservation(Long scheduleId, int seatCount);
 
+    // 예약 취소 시 랭킹 차감
+    void decrementReservation(Long scheduleId, int seatCount);
+
     // 빠른 판매 랭킹 조회
     List<ConcertRankingDto> getFastSellingRanking(int limit);
 

--- a/src/main/java/kr/hhplus/be/server/application/port/in/ReservationUseCase.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/in/ReservationUseCase.java
@@ -50,8 +50,23 @@ public interface ReservationUseCase {
             LocalDateTime expirationTime
     ) {}
 
+    record CancelReservationCommand(
+            String queueToken,      // 선택사항 - 없어도 될 수도
+            String reservationId,
+            String userId,
+            String reason           // 취소 사유 (선택)
+    ) {}
+
+    record CancelReservationResult(
+            String reservationId,
+            Long refundAmount,      // 환불 금액
+            LocalDateTime cancelledAt
+    ) {}
+
     // Use Case 메서드들
     TemporaryAssignResult temporaryAssign(TemporaryAssignCommand command);
     ConfirmReservationResult confirmReservation(ConfirmReservationCommand command);
     ReservationInfo getReservation(ReservationQuery query);
+    CancelReservationResult cancelReservation(CancelReservationCommand command);
+
 }

--- a/src/main/java/kr/hhplus/be/server/application/port/out/RankingPort.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/out/RankingPort.java
@@ -13,11 +13,17 @@ public interface RankingPort {
     // 판매 수량 증가
     long incrementSoldCount(String scheduleId, int increment);
 
+    // 판매 수량 감소 (예약 취소 시)
+    long decrementSoldCount(String scheduleId, int decrement);
+
     // 첫 판매 시간 설정
     boolean setStartTimeIfAbsent(String scheduleId, long startTime);
 
     // 판매 속도 랭킹 업데이트
     void updateVelocityRanking(String scheduleId, double score);
+
+    // 판매 속도 랭킹에서 제거 (모든 예약 취소 시)
+    void removeFromVelocityRanking(String scheduleId);
 
     // 매진 랭킹 업데이트
     void updateSoldOutRanking(String scheduleId, long seconds);

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/payment/jpa/repository/UserWalletJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/payment/jpa/repository/UserWalletJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface UserWalletJpaRepository extends JpaRepository<UserWalletJpaEntity, UUID> {
 
-    // 결제/충전 시 동시성 제어용 (행 잠금)
+    // 결제/충전 시 동시성 제어용
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select w from UserWalletJpaEntity w where w.userId = :userId")
     Optional<UserWalletJpaEntity> findForUpdate(@Param("userId") UUID userId);

--- a/src/test/java/kr/hhplus/be/server/concurrency/ConditionalUpdateConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/ConditionalUpdateConcurrencyTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.concurrency;
 
 import kr.hhplus.be.server.concurrency.config.TestTaskExecutorConfig;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * - 단일 쿼리로 원자적 처리
  */
 
+@Disabled("MySQL 조건부 UPDATE 방식 → Redis 분산락으로 전환하여 현재는 사용 안 함")
 @SpringBootTest
 @Import(TestTaskExecutorConfig.class)
 @TestPropertySource(properties = {

--- a/src/test/java/kr/hhplus/be/server/concurrency/DomainLogicConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/DomainLogicConcurrencyTest.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.concurrency;
 
 import kr.hhplus.be.server.concurrency.config.TestTaskExecutorConfig;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * - 비관적 락(SELECT FOR UPDATE) 또는 낙관적 락(@Version) 사용
  * - PaymentService의 기본 동작 방식
  */
-
+@Disabled("MySQL 락 방식 → Redis 분산락으로 전환")
 @SpringBootTest
 @Import(TestTaskExecutorConfig.class)
 @TestPropertySource(properties = {

--- a/src/test/java/kr/hhplus/be/server/concurrency/ExtremeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/ExtremeConcurrencyTest.java
@@ -9,6 +9,7 @@ import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.entity.UserWal
 import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.repository.UserWalletJpaRepository;
 import kr.hhplus.be.server.infrastructure.persistence.reservation.jpa.repository.SeatHoldJpaRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * - 대규모 동시 요청 시나리오
  * - TaskExecutor로 안정적인 스레드 관리
  */
+@Disabled("성능 테스트. 시간이 오래 걸려 CI에서 제외. 로컬에서 필요시 직접 실행")
 @Slf4j
 @SpringBootTest
 @Import(TestTaskExecutorConfig.class)

--- a/src/test/java/kr/hhplus/be/server/concurrency/ReservationConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/ReservationConcurrencyTest.java
@@ -13,6 +13,7 @@ import kr.hhplus.be.server.infrastructure.persistence.queue.jpa.entity.QueueToke
 import kr.hhplus.be.server.infrastructure.persistence.queue.jpa.repository.QueueTokenJpaRepository;
 import kr.hhplus.be.server.infrastructure.redis.lock.LockAcquisitionException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * 분산락 통합 테스트 (실제 DB + Redis)
  */
+@Disabled("Testcontainers 방식(ConcurrencyIntegrationTest)으로 개선되어 현재는 사용 안 함")
 @SpringBootTest
 @DisplayName("분산락 통합 테스트")
 class ReservationConcurrencyTest {

--- a/src/test/java/kr/hhplus/be/server/event/ReservationEventAfterCommitTest.java
+++ b/src/test/java/kr/hhplus/be/server/event/ReservationEventAfterCommitTest.java
@@ -1,0 +1,291 @@
+package kr.hhplus.be.server.event;
+
+import kr.hhplus.be.server.application.port.in.QueueUseCase;
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.port.in.ReservationUseCase;
+import kr.hhplus.be.server.application.service.ReservationService;
+import kr.hhplus.be.server.domain.common.Money;
+import kr.hhplus.be.server.domain.common.UserId;
+import kr.hhplus.be.server.domain.concert.ConcertScheduleId;
+import kr.hhplus.be.server.domain.reservation.*;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.entity.ConcertJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.entity.ConcertScheduleJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.repository.ConcertJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.repository.ConcertScheduleJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.entity.UserWalletJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.repository.UserWalletJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.user.jpa.entity.UserJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.user.jpa.repository.UserJpaRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * AFTER_COMMIT 동작 검증 통합 테스트
+ *
+ * 목적:
+ * - TransactionalEventListener(AFTER_COMMIT)가 트랜잭션 커밋 후에만 실행되는지 검증
+ * - 트랜잭션 실패 시 이벤트가 발행되지 않는지 검증
+ *
+ * 멘토님 피드백 반영
+ * 1. 트랜잭션에 실패하는 경우(커밋이 이루어지지 않는 경우) 이벤트 리스너가 call 되지 않는다는 것을 검증
+ * 2. 트랜잭션이 완료되기 전 이벤트 리스너의 call count가 0인것과,
+ *    트랜잭션이 완료된 직후 call count가 1인것을 검증
+ */
+@Slf4j
+@SpringBootTest
+@DisplayName("AFTER_COMMIT 동작 검증")
+class ReservationEventAfterCommitTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private UserWalletJpaRepository walletJpaRepository;
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private ConcertScheduleJpaRepository scheduleJpaRepository;
+
+    @Autowired
+    private QueueUseCase queueUseCase;
+
+    @MockitoSpyBean
+    private RankingUseCase rankingUseCase;
+
+    private UUID userId;
+    private String queueToken;
+    private Long scheduleId;
+    private String reservationId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        UserJpaEntity user = new UserJpaEntity(userId, "테스트사용자_" + System.currentTimeMillis());
+        userJpaRepository.save(user);
+
+        UserWalletJpaEntity wallet = new UserWalletJpaEntity(userId, 200_000L);
+        walletJpaRepository.save(wallet);
+
+        ConcertJpaEntity concert = new ConcertJpaEntity("테스트 콘서트");
+        concert = concertJpaRepository.save(concert);
+
+        ConcertScheduleJpaEntity schedule = new ConcertScheduleJpaEntity(
+                concert,
+                LocalDate.now().plusDays(30),
+                50
+        );
+        schedule = scheduleJpaRepository.save(schedule);
+        scheduleId = schedule.getId();
+
+        QueueUseCase.IssueTokenCommand tokenCommand =
+                new QueueUseCase.IssueTokenCommand(userId.toString());
+        QueueUseCase.TokenInfo tokenInfo = queueUseCase.issueToken(tokenCommand);
+        queueToken = tokenInfo.token();
+
+        reservationId = UUID.randomUUID().toString();
+        Reservation reservation = Reservation.restore(
+                new ReservationId(reservationId),
+                UserId.of(userId),
+                new SeatIdentifier(
+                        new ConcertScheduleId(scheduleId),
+                        new SeatNumber(10)
+                ),
+                Money.of(80_000L),
+                ReservationStatus.TEMPORARY_ASSIGNED,
+                LocalDateTime.now().minusMinutes(2),
+                null,
+                0L
+        );
+        reservationRepository.save(reservation);
+    }
+
+    @Test
+    @DisplayName("트랜잭션 실패 시 이벤트가 발행되지 않음 (AFTER_COMMIT 검증)")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void transactionRollback_eventNotPublished() throws InterruptedException {
+        // given - 잔액 부족 상황 (결제 실패 -> 트랜잭션 롤백)
+        UserWalletJpaEntity wallet = walletJpaRepository.findById(userId).orElseThrow();
+        wallet.setBalance(1_000L);  // 80,000원 필요한데 1,000원만 있음
+        walletJpaRepository.save(wallet);
+
+        // 이벤트 리스너 호출 횟수 초기화
+        reset(rankingUseCase);
+
+        // when - 예약 확정 시도 (실패할 것)
+        ReservationUseCase.ConfirmReservationCommand command =
+                new ReservationUseCase.ConfirmReservationCommand(
+                        queueToken,
+                        reservationId,
+                        UUID.randomUUID().toString()
+                );
+
+        // then - 결제 실패로 예외 발생
+        try {
+            reservationService.confirmReservation(command);
+        } catch (Exception e) {
+            log.info("예상된 예외 발생: {}", e.getMessage());
+        }
+
+        // 충분한 시간 대기 (이벤트가 발행됐다면 처리될 시간)
+        Thread.sleep(3000);
+
+        // 트랜잭션이 롤백되었으므로 이벤트 리스너가 호출되지 않아야 함
+        verify(rankingUseCase, never())
+                .trackReservation(anyLong(), anyInt());
+
+        // 예약 상태도 변경되지 않아야 함
+        Reservation reservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.TEMPORARY_ASSIGNED);
+
+        log.info("검증 완료: 트랜잭션 롤백 시 이벤트 미발행");
+    }
+
+    @Test
+    @DisplayName("트랜잭션 커밋 전후 이벤트 리스너 호출 시점 검증")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void eventListener_calledAfterTransactionCommit() throws InterruptedException {
+        // given
+        reset(rankingUseCase);
+
+        // when
+        ReservationUseCase.ConfirmReservationCommand command =
+                new ReservationUseCase.ConfirmReservationCommand(
+                        queueToken,
+                        reservationId,
+                        UUID.randomUUID().toString()
+                );
+
+        // 트랜잭션 실행 중
+        ReservationUseCase.ConfirmReservationResult result =
+                reservationService.confirmReservation(command);
+
+        // 트랜잭션은 완료되었지만 비동기 이벤트는 아직 처리 중일 수 있음
+        // 짧은 시간 대기 후 확인
+        Thread.sleep(100);
+
+        // 비동기 처리 완료 대기
+        Thread.sleep(3000);
+
+        // then - 트랜잭션 커밋 후 이벤트 리스너가 호출됨
+        verify(rankingUseCase, times(1))
+                .trackReservation(eq(scheduleId), eq(1));
+
+        // 예약 상태도 확정되어 있어야 함
+        Reservation confirmedReservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        assertThat(confirmedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+        assertThat(result.remainingBalance()).isEqualTo(120_000L);
+
+        log.info("검증 완료: 트랜잭션 커밋 후 이벤트 발행");
+    }
+
+    @Test
+    @DisplayName("예약 취소 시 랭킹 차감 이벤트 발행")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void cancelReservation_triggersDecrementEvent() throws InterruptedException {
+        // given
+        // 먼저 예약을 확정 상태로 만들기
+        Reservation reservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        reservation.confirm(LocalDateTime.now());
+        reservationRepository.save(reservation);
+
+        reset(rankingUseCase);  // Mock 초기화
+
+        // when - 예약 취소
+        ReservationUseCase.CancelReservationCommand command =
+                new ReservationUseCase.CancelReservationCommand(
+                        null,                    // queueToken (취소는 대기열 검증 불필요)
+                        reservationId,           // reservationId
+                        userId.toString(),       // userId
+                        "테스트 취소"             // reason
+                );
+
+        reservationService.cancelReservation(command);
+
+        // 비동기 이벤트 처리 완료 대기
+        Thread.sleep(3000);
+
+        // then - decrementReservation 호출 확인
+        verify(rankingUseCase, times(1))
+                .decrementReservation(eq(scheduleId), eq(1));
+
+        // 예약 상태도 CANCELLED로 변경되어야 함
+        Reservation cancelledReservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        assertThat(cancelledReservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+
+        log.info("검증 완료: 예약 취소 시 랭킹 차감 이벤트 정상 발행");
+    }
+
+    @Test
+    @DisplayName("예약 취소 이벤트 리스너 예외 발생 시에도 취소는 성공")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void cancelEventListenerException_doesNotAffectCancellation() throws InterruptedException {
+        // given
+        Reservation reservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        reservation.confirm(LocalDateTime.now());
+        reservationRepository.save(reservation);
+
+        reset(rankingUseCase);
+
+        // 랭킹 서비스가 예외를 던지도록 설정
+        doThrow(new RuntimeException("랭킹 업데이트 실패"))
+                .when(rankingUseCase).decrementReservation(anyLong(), anyInt());
+
+        // when - 예약 취소 (이벤트 리스너에서 예외 발생)
+        ReservationUseCase.CancelReservationCommand command =
+                new ReservationUseCase.CancelReservationCommand(
+                        null,                    // queueToken
+                        reservationId,           // reservationId
+                        userId.toString(),       // userId
+                        "이벤트 실패 테스트"      // reason
+                );
+
+        ReservationUseCase.CancelReservationResult result =
+                reservationService.cancelReservation(command);
+
+        // 비동기 이벤트 처리 시도 대기
+        Thread.sleep(3000);
+
+        // then - 예약 취소는 성공해야 함
+        assertThat(result).isNotNull();
+
+        Reservation cancelledReservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        assertThat(cancelledReservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+
+        // 이벤트 리스너는 호출되었지만 예외로 인해 실패
+        verify(rankingUseCase, times(1))
+                .decrementReservation(anyLong(), anyInt());
+
+        log.info("검증 완료: 이벤트 리스너 예외가 핵심 비즈니스에 영향 없음");
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/event/ReservationEventIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/event/ReservationEventIntegrationTest.java
@@ -1,0 +1,215 @@
+package kr.hhplus.be.server.event;
+
+import kr.hhplus.be.server.application.port.in.QueueUseCase;
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import kr.hhplus.be.server.application.port.in.ReservationUseCase;
+import kr.hhplus.be.server.application.service.ReservationService;
+import kr.hhplus.be.server.domain.common.Money;
+import kr.hhplus.be.server.domain.common.UserId;
+import kr.hhplus.be.server.domain.concert.ConcertScheduleId;
+import kr.hhplus.be.server.domain.reservation.*;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.entity.ConcertJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.entity.ConcertScheduleJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.repository.ConcertJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.concert.jpa.repository.ConcertScheduleJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.entity.UserWalletJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.payment.jpa.repository.UserWalletJpaRepository;
+import kr.hhplus.be.server.infrastructure.persistence.user.jpa.entity.UserJpaEntity;
+import kr.hhplus.be.server.infrastructure.persistence.user.jpa.repository.UserJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 예약 확정 이벤트 통합 테스트
+ */
+@SpringBootTest
+@DisplayName("예약 확정 이벤트 통합 테스트")
+class ReservationEventIntegrationTest {
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private UserWalletJpaRepository walletJpaRepository;
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private ConcertScheduleJpaRepository scheduleJpaRepository;
+
+    @Autowired
+    private QueueUseCase queueUseCase;
+
+    @MockitoSpyBean
+    private RankingUseCase rankingUseCase;
+
+    private UUID userId;
+    private String queueToken;
+    private Long scheduleId;
+    private String reservationId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        UserJpaEntity user = new UserJpaEntity(userId, "테스트사용자_" + System.currentTimeMillis());
+        userJpaRepository.save(user);
+
+        UserWalletJpaEntity wallet = new UserWalletJpaEntity(userId, 200_000L);
+        walletJpaRepository.save(wallet);
+
+        ConcertJpaEntity concert = new ConcertJpaEntity("테스트 콘서트");
+        concert = concertJpaRepository.save(concert);
+
+        ConcertScheduleJpaEntity schedule = new ConcertScheduleJpaEntity(
+                concert,
+                LocalDate.now().plusDays(30),
+                50
+        );
+        schedule = scheduleJpaRepository.save(schedule);
+        scheduleId = schedule.getId();
+
+        QueueUseCase.IssueTokenCommand tokenCommand =
+                new QueueUseCase.IssueTokenCommand(userId.toString());
+        QueueUseCase.TokenInfo tokenInfo = queueUseCase.issueToken(tokenCommand);
+        queueToken = tokenInfo.token();
+
+        reservationId = UUID.randomUUID().toString();
+        Reservation reservation = Reservation.restore(
+                new ReservationId(reservationId),
+                UserId.of(userId),
+                new SeatIdentifier(
+                        new ConcertScheduleId(scheduleId),
+                        new SeatNumber(10)
+                ),
+                Money.of(80_000L),
+                ReservationStatus.TEMPORARY_ASSIGNED,
+                LocalDateTime.now().minusMinutes(2),
+                null,
+                0L
+        );
+        reservationRepository.save(reservation);
+    }
+
+    @Test
+    @DisplayName("예약 확정 성공 시 이벤트가 발행되고 리스너가 실행됨")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void confirmReservation_success_triggersEvent() throws InterruptedException {
+        ReservationUseCase.ConfirmReservationCommand command =
+                new ReservationUseCase.ConfirmReservationCommand(
+                        queueToken,
+                        reservationId,
+                        UUID.randomUUID().toString()
+                );
+
+        ReservationUseCase.ConfirmReservationResult result =
+                reservationService.confirmReservation(command);
+
+        Thread.sleep(3000);
+
+        assertThat(result).isNotNull();
+        assertThat(result.remainingBalance()).isEqualTo(120_000L);
+
+        verify(rankingUseCase, timeout(5000).times(1))
+                .trackReservation(eq(scheduleId), eq(1));
+
+        Reservation confirmedReservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        assertThat(confirmedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("여러 예약 확정 시 모든 이벤트가 처리됨")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void multipleReservations_allEventsProcessed() throws InterruptedException {
+        int additionalReservations = 2;
+        for (int i = 1; i <= additionalReservations; i++) {
+            String newReservationId = UUID.randomUUID().toString();
+            Reservation reservation = Reservation.restore(
+                    new ReservationId(newReservationId),
+                    UserId.of(userId),
+                    new SeatIdentifier(
+                            new ConcertScheduleId(scheduleId),
+                            new SeatNumber(10 + i)
+                    ),
+                    Money.of(80_000L),
+                    ReservationStatus.TEMPORARY_ASSIGNED,
+                    LocalDateTime.now().minusMinutes(2),
+                    null,
+                    0L
+            );
+            reservationRepository.save(reservation);
+
+            UserWalletJpaEntity wallet = walletJpaRepository.findById(userId)
+                    .orElseThrow();
+            wallet.setBalance(wallet.getBalance() + 80_000L);
+            walletJpaRepository.save(wallet);
+        }
+
+        ReservationUseCase.ConfirmReservationCommand command =
+                new ReservationUseCase.ConfirmReservationCommand(
+                        queueToken,
+                        reservationId,
+                        UUID.randomUUID().toString()
+                );
+
+        reservationService.confirmReservation(command);
+
+        Thread.sleep(3000);
+
+        verify(rankingUseCase, times(1))
+                .trackReservation(eq(scheduleId), eq(1));
+    }
+
+    @Test
+    @DisplayName("이벤트 리스너 예외 발생 시에도 예약 확정은 성공")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void eventListenerException_doesNotAffectReservation() throws InterruptedException {
+        doThrow(new RuntimeException("Redis 연결 실패"))
+                .when(rankingUseCase)
+                .trackReservation(anyLong(), anyInt());
+
+        ReservationUseCase.ConfirmReservationCommand command =
+                new ReservationUseCase.ConfirmReservationCommand(
+                        queueToken,
+                        reservationId,
+                        UUID.randomUUID().toString()
+                );
+
+        ReservationUseCase.ConfirmReservationResult result =
+                reservationService.confirmReservation(command);
+
+        Thread.sleep(3000);
+
+        assertThat(result).isNotNull();
+        assertThat(result.remainingBalance()).isEqualTo(120_000L);
+
+        verify(rankingUseCase, times(1))
+                .trackReservation(anyLong(), anyInt());
+
+        Reservation confirmedReservation = reservationRepository.findById(new ReservationId(reservationId))
+                .orElseThrow();
+        assertThat(confirmedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/event/ReservationEventListenerTest.java
+++ b/src/test/java/kr/hhplus/be/server/event/ReservationEventListenerTest.java
@@ -1,0 +1,121 @@
+package kr.hhplus.be.server.event;
+
+import kr.hhplus.be.server.application.event.ReservationConfirmedEvent;
+import kr.hhplus.be.server.application.event.ReservationEventListener;
+import kr.hhplus.be.server.application.port.in.RankingUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * 예약 이벤트 리스너 단위 테스트
+ */
+@ExtendWith(MockitoExtension.class)  // ← Spring 없이 순수 Mockito!
+@DisplayName("예약 이벤트 리스너 단위 테스트")
+class ReservationEventListenerTest {
+
+    @Mock  // ← @MockBean 대신 @Mock 사용
+    private RankingUseCase rankingUseCase;
+
+    @InjectMocks  // ← 자동으로 Mock 주입
+    private ReservationEventListener listener;
+
+    @Test
+    @DisplayName("랭킹 업데이트 - 정상 동작")
+    void updateRanking_Success() {
+        // given
+        ReservationConfirmedEvent event = ReservationConfirmedEvent.of(
+                "reservation-123",
+                "user-456",
+                1L,
+                10,
+                100_000L,
+                LocalDateTime.now()
+        );
+
+        // when
+        listener.updateRanking(event);
+
+        // then
+        verify(rankingUseCase, times(1))
+                .trackReservation(eq(1L), eq(1));
+    }
+
+    @Test
+    @DisplayName("랭킹 업데이트 - 예외 발생해도 처리 완료")
+    void updateRanking_WithException_DoesNotThrow() {
+        // given
+        ReservationConfirmedEvent event = ReservationConfirmedEvent.of(
+                "reservation-123",
+                "user-456",
+                1L,
+                10,
+                100_000L,
+                LocalDateTime.now()
+        );
+
+        // rankingUseCase 호출 시 예외 발생
+        doThrow(new RuntimeException("Redis 연결 실패"))
+                .when(rankingUseCase)
+                .trackReservation(anyLong(), anyInt());
+
+        // when & then - 예외가 발생해도 메서드는 정상 종료
+        listener.updateRanking(event);
+
+        // 한 번은 호출됨
+        verify(rankingUseCase, times(1))
+                .trackReservation(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("데이터 플랫폼 전송 - 정상 동작")
+    void sendToDataPlatform_Success() {
+        // given
+        ReservationConfirmedEvent event = ReservationConfirmedEvent.of(
+                "reservation-123",
+                "user-456",
+                1L,
+                10,
+                100_000L,
+                LocalDateTime.now()
+        );
+
+        // when
+        listener.sendToDataPlatform(event);
+
+        // then - 예외 없이 완료되면 성공
+        // Mock API 호출은 실제로 아무것도 안 하므로 예외만 안 나면 OK
+    }
+
+    @Test
+    @DisplayName("여러 이벤트 연속 처리")
+    void processMultipleEvents() {
+        // given
+        for (int i = 1; i <= 5; i++) {
+            ReservationConfirmedEvent event = ReservationConfirmedEvent.of(
+                    "reservation-" + i,
+                    "user-" + i,
+                    (long) i,
+                    10 + i,
+                    100_000L * i,
+                    LocalDateTime.now()
+            );
+
+            // when
+            listener.updateRanking(event);
+            listener.sendToDataPlatform(event);
+        }
+
+        // then
+        verify(rankingUseCase, times(5))
+                .trackReservation(anyLong(), anyInt());
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/integration/ConcurrencyIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/ConcurrencyIntegrationTest.java
@@ -53,6 +53,7 @@ public class ConcurrencyIntegrationTest {
     @Qualifier("concurrencyTestExecutor")
     private TaskExecutor taskExecutor;
 
+
     @Autowired
     @Qualifier("singleThreadTestExecutor")
     private TaskExecutor singleThreadExecutor;


### PR DESCRIPTION
## PR 설명

### 📌 과제 요약
**Application Event & Transaction Diagnosis**

#### 필수과제: Application Event
예약 확정 시 랭킹 업데이트를 이벤트 기반으로 분리하여 트랜잭션과 관심사를 분리했습니다.

`@TransactionalEventListener(AFTER_COMMIT)` 사용

#### 선택과제: Transaction Diagnosis
MSA 전환 시 도메인 분리와 분산 트랜잭션 문제를 분석하고 해결 방안을 문서화했습니다.

 ---

## Definition of Done (DoD)

### 기능 구현
- [x] `ReservationConfirmedEvent` 도메인 이벤트 구현
- [x] `ReservationEventListener` 이벤트 리스너 구현
- [x] `@TransactionalEventListener(AFTER_COMMIT)` 적용
- [x] 예약 확정 후 랭킹 업데이트 비동기 처리
- [x] 이벤트 실패 시에도 예약은 성공하도록 보장

### 테스트
- [x] 예약 이벤트 통합 테스트 작성
- [x] 예약 이벤트 단위 테스트 작성 
- [x] 이벤트 실패 시나리오 테스트
- [x] 비동기 처리 검증

### 문서화
- [x] MSA 전환 설계 문서 작성 완료
- [x] 6개 서비스 분리 근거 및 책임 정의
- [x] 분산 트랜잭션 한계 분석
- [x] 3가지 해결 방안 정리
- [x] 실제 코드 기반 예시 포함

## 리뷰 포인트

### 1. 이벤트 실패 처리
```java
catch (Exception e) {
    log.warn("⚠️ [Ranking] 랭킹 업데이트 실패 (무시)");
}
```
랭킹이 실패해도 예약은 성공한 상태인데, 그냥 로그만 남기고 넘어가도 괜찮을까요? 재시도하거나 복구하는 방법이 필요할까요?

### 2. AFTER_COMMIT이 정말 동작하는지 확인하고 싶어요

**현재 테스트:**
```java
void eventListenerException_doesNotAffectReservation() throws InterruptedException {
        doThrow(new RuntimeException("Redis 연결 실패"))
                .when(rankingUseCase)
                .trackReservation(anyLong(), anyInt());

        ReservationUseCase.ConfirmReservationCommand command =
                new ReservationUseCase.ConfirmReservationCommand(
                        queueToken,
                        reservationId,
                        UUID.randomUUID().toString()
                );

        ReservationUseCase.ConfirmReservationResult result =
                reservationService.confirmReservation(command);

        Thread.sleep(3000);

        assertThat(result).isNotNull();
        assertThat(result.remainingBalance()).isEqualTo(120_000L);

        verify(rankingUseCase, times(1))
                .trackReservation(anyLong(), anyInt());

        Reservation confirmedReservation = reservationRepository.findById(new ReservationId(reservationId))
                .orElseThrow();
        assertThat(confirmedReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
    }
```

이 테스트는 "랭킹 실패해도 예약 성공"은 검증하는데 "트랜잭션 커밋 후에 이벤트가 발행됐다"는 어떻게 증명하나요?
그냥 AFTER_COMMIT은 정상 커밋 이후 실행된다는 것을 보장하니까 믿어도 될까요?

### 3. 이벤트를 어디까지 만들어야 할까요?
예약 취소할 때도 이벤트를 만들어야 할까요? 아니면 취소는 직접 랭킹을 차감해도 괜찮을까요?
```